### PR TITLE
Update requirements

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -15,6 +15,7 @@
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>
+            <module name="Magento_GiftWrapping" />
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Line 90 in Astound\Affirm\Model\GiftWrapManager.php expects the giftwrapping module to be enabled. If module is not enabled, the affirm module breaks checkout.