### PR TITLE
Add support for Bundled and Grouped Product price-type's to aslowasPLP.js

### DIFF
--- a/view/frontend/web/js/aslowasPLP.js
+++ b/view/frontend/web/js/aslowasPLP.js
@@ -21,7 +21,7 @@ define(["jquery",
          */
         initPrices: function() {
             var elements = $(document)
-                    .find("[data-price-type='finalPrice'], [data-price-type='minPrice']"),
+                    .find("[data-price-type='finalPrice'], [data-price-type='minPrice'], [data-price-type='starting-price']"),
                 price,
                 options,
                 element_id,
@@ -98,7 +98,7 @@ define(["jquery",
                 if ($.contains(priceInfo, currentElement)) {
                     price = $(el[0]).find("[data-price-type='finalPrice'], [data-price-type='minPrice']").text();
                     options = this.options;
-                    options.element_id = 'as_low_as_plp_' + $(el[0]).find("[data-price-type='finalPrice'], [data-price-type='minPrice']").parent().parent().parent().attr('data-product-id');
+                    options.element_id = 'as_low_as_plp_' + $(el[0]).find("[data-price-type='finalPrice'], [data-price-type='minPrice'], [data-price-type='starting-price']").parent().parent().parent().attr('data-product-id');
                     aslowas.process(price, options);
                 }
             }


### PR DESCRIPTION
The Affirm burst does now show below Magento v2's Bundled or Grouped Product types because the `data-price-type` for those is "starting-price" instead of "finalPrice" or "minPrice".

This branch makes it so that the Affirm burst shows up below Magento v2's Bundled and Grouped Products as well as Simple Products.
