### PR TITLE
remove controller action

### DIFF
--- a/Model/Observer/IdentifyFinancingProgram.php
+++ b/Model/Observer/IdentifyFinancingProgram.php
@@ -21,6 +21,7 @@ namespace Astound\Affirm\Model\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Customer\Model\Session;
+use Magento\Framework\App\RequestInterface;
 
 /**
  * Identify Financing Program for customer
@@ -32,9 +33,11 @@ class IdentifyFinancingProgram implements ObserverInterface
      *
      */
     public function __construct(
-        Session $customerSession
+        Session $customerSession,
+        RequestInterface $request
     ) {
         $this->_customerSession = $customerSession;
+        $this->request = $request;
     }
 
     /**
@@ -45,8 +48,8 @@ class IdentifyFinancingProgram implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
-        $controller = $observer->getControllerAction();
-        $financingProgramValue = $controller->getRequest()->getParam('affirm_fpid');
+
+        $financingProgramValue = $this->request->getParam('affirm_fpid');
         if (empty($financingProgramValue)) {
             return;
         }


### PR DESCRIPTION
---
name: remove controller action
---

### Description
removing the use of controller action 

### How To Reproduce
Steps to reproduce the behavior:
1. add affirm_fpid to the query string on the homepage.  affirm_fpid should be a financing program
2.checkout and make sure the above financing up program is on checkout


### Expected behavior
financing program on checkout

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
Magento is no longer supporting controller actions from the observer 

