### PR TITLE
Feature request: Show Affirm button in minicart

### DIFF
--- a/Block/System/Config/Form/Field/Date.php
+++ b/Block/System/Config/Form/Field/Date.php
@@ -62,7 +62,7 @@ class Date extends \Magento\Config\Block\System\Config\Form\Field
             $this->_coreRegistry->registry('datepicker_loaded', 1);
         }
         $html .= '<script type="text/javascript">
-            require(["jquery", "jquery-ui-modules/widget"], function () {
+            require(["jquery"], function () {
                 jQuery(document).ready(function () {
                     jQuery("#' . $element->getHtmlId() . '").datepicker( { dateFormat: "mm/dd/yy" } );
                     var el = document.getElementById("' . $element->getHtmlId() . '");

--- a/Block/System/Config/Form/Field/Date.php
+++ b/Block/System/Config/Form/Field/Date.php
@@ -62,7 +62,7 @@ class Date extends \Magento\Config\Block\System\Config\Form\Field
             $this->_coreRegistry->registry('datepicker_loaded', 1);
         }
         $html .= '<script type="text/javascript">
-            require(["jquery", "jquery/ui"], function () {
+            require(["jquery", "jquery-ui-modules/widget"], function () {
                 jQuery(document).ready(function () {
                     jQuery("#' . $element->getHtmlId() . '").datepicker( { dateFormat: "mm/dd/yy" } );
                     var el = document.getElementById("' . $element->getHtmlId() . '");

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "affirm/magento2",
     "description": "Affirm's extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "license": [
         "BSD-3-Clause"
     ],

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -46,6 +46,7 @@
                 <enable_checkout_button>0</enable_checkout_button>
                 <checkout_button_code>https://cdn-assets.affirm.com/images/buttons/30_148-white.png</checkout_button_code>
                 <checkout_button_width>148</checkout_button_width>
+                <checkout_flow_type>Modal</checkout_flow_type>
                 <notification>
                     <notification_update>1</notification_update>
                 </notification>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Astound_Affirm" setup_version="3.0.3">
+    <module name="Astound_Affirm" setup_version="3.0.4">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>

--- a/view/frontend/templates/pixel/code.phtml
+++ b/view/frontend/templates/pixel/code.phtml
@@ -87,7 +87,7 @@ if ($action == 'catalog_product_view' && $block->isProductViewTrackPixelEnabled(
     if($block->isAddCartTrackPixelEnabled()){
     ?>
     <script>
-        require(['jquery', 'jquery/ui'],function($){
+        require(['jquery', 'jquery-ui-modules/widget'],function($){
 
             $('#product-addtocart-button').click(function () {
                 

--- a/view/frontend/web/js/affirmPixel.js
+++ b/view/frontend/web/js/affirmPixel.js
@@ -36,7 +36,7 @@
 define([
     "jquery",
     "Astound_Affirm/js/model/aslowas",
-    "jquery/ui"
+    "jquery-ui-modules/widget"
 ], function ($, aslowas) {
     "use strict"
 

--- a/view/frontend/web/js/affirmWidget.js
+++ b/view/frontend/web/js/affirmWidget.js
@@ -7,7 +7,7 @@
 define([
     "jquery",
     "Astound_Affirm/js/model/aslowas",
-    "jquery/ui"
+    "jquery-ui-modules/widget"
 ], function ($, aslowas) {
 
     "use strict"

--- a/view/frontend/web/js/aslowasPDP.js
+++ b/view/frontend/web/js/aslowasPDP.js
@@ -6,7 +6,7 @@
 define(["jquery",
     "mage/translate",
     "Astound_Affirm/js/model/aslowas",
-    "jquery/ui"
+    "jquery-ui-modules/widget"
 ], function ($, $t, aslowas) {
 
     "use strict"

--- a/view/frontend/web/js/aslowasPLP.js
+++ b/view/frontend/web/js/aslowasPLP.js
@@ -6,7 +6,7 @@
 define(["jquery",
     "mage/translate",
     "Astound_Affirm/js/model/aslowas",
-    "jquery/ui"
+    "jquery-ui-modules/widget"
 ], function ($, $t, aslowas) {
 
     "use strict"

--- a/view/frontend/web/js/model/global.js
+++ b/view/frontend/web/js/model/global.js
@@ -36,7 +36,7 @@
 define([
     "jquery",
     "mage/translate",
-    "jquery/ui"
+    "jquery-ui-modules/widget"
 ],
     function ($, $t) {
         'use strict';


### PR DESCRIPTION
Do you have any plans to add the Affirm button to the minicart? 

![Shopping Cart _ 21st Century Task Seating - Google Chrome 2021-02-19 12 30 29](https://user-images.githubusercontent.com/129031/108546110-4a381f00-72ae-11eb-87fd-7de517f33b2b.png)


We currently have our other payment methods showing in the minicart, and we'd like to have Affirm showing (just like it does in the cart).

Feel free to close this PR and direct me to where to submit feature requests.