### PR TITLE
Bug fix for PSE-502 500 error for inline api call on closing Affirm payment window

### DIFF
--- a/Model/InlineCheckout.php
+++ b/Model/InlineCheckout.php
@@ -161,8 +161,8 @@ class InlineCheckout implements InlineCheckoutInterface
                     'last'  => $address->getLastName(),
                 ),
                 'address' => array(
-                    'line1'   => $street[0] ? $street[0] : '',
-                    'line2'   => $street[1] ? $street[1] : '',
+                    'line1'   => isset($street[0]) ? $street[0] : '',
+                    'line2'   => isset($street[1]) ? $street[1] : '',
                     'city'    => $address->getCity(),
                     'state'   => $address->getRegion(),
                     'zipcode' => $address->getPostcode(),


### PR DESCRIPTION
Bugfix for PSE-502 500 error for inline api call on closing Affirm payment window

---
Fix for PSE-502
---

### Description
If you decide to cancel Affirm payment and come back on the checkout page, for some Magento versions it removes the shipping address hence causing an error on the address street index. This fix only fixes the indexing error so after populating the address inline checkout works again.

Magento shipping address not saved post page refresh on checkout [issue](https://support.magento.com/hc/en-us/articles/360025843552-Shipping-address-not-saved-post-page-refresh-on-checkout-) is known for 2.2.3 version, on cancelling the payment window it takes you back to the shipping page instead of checkout and the user needs to populate the address again.

