### PR TITLE
Double email confirmation fix

### DIFF
--- a/Model/Checkout.php
+++ b/Model/Checkout.php
@@ -172,7 +172,8 @@ class Checkout
             case \Magento\Sales\Model\Order::STATE_PROCESSING:
             case \Magento\Sales\Model\Order::STATE_COMPLETE:
             case \Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW:
-                $this->orderSender->send(($this->order));
+                if (!$this->order->getEmailSent()) // Check if order confirmation has already been sent, prevent double email notification.
+                    $this->orderSender->send(($this->order));
                 $this->checkoutSession->start();
                 break;
             default:


### PR DESCRIPTION
---
Double email confirmation fix
---

### Description
<!--- Describe the Bug/feature/enhancement you are adding in this PR. -->

### How To Reproduce
Steps to reproduce the behavior:
1. Place an order with Affirm payment method.
2. Receive double order confirmation through email.

### Expected behavior
Receive only one order confirmation

### Screenshots

![image](https://user-images.githubusercontent.com/32687858/118172887-c2ac0900-b3e1-11eb-9249-4fbaee33a6b6.png)

