### PR TITLE
Format PDP price to have only two decimal places

### DIFF
--- a/view/frontend/web/js/model/aslowas.js
+++ b/view/frontend/web/js/model/aslowas.js
@@ -39,7 +39,7 @@ define([
                     formatted = formatted / options.currency_rate;
                     formatted = formatted.toFixed(2);
                 }
-                priceInt = formatted * 100;
+                priceInt = Math.floor((formatted * 100).toFixed(2));
 
                 if (options) {
                     self.options = options;


### PR DESCRIPTION
### Description
To comply with the financial regulatory measures was requested to have the amount be shown only with two decimal places on the PDP content. In certaincircustances the price can have infinite amount of decimal places based on the rules of the discunt rules.

### How To Reproduce
Steps to reproduce the behavior:
1. Set a product with price $69.99
2. Enter to the PDP page
3. Open the code inspector and search <div id="als_pdp"
4. The tag data-amount has more than 2 decimals.

### Expected behavior
The price should be shown with 2 decimal places only.

### Additional information
- Tested on Magento 2.3 & 2.4.
- Version 3.0.10 of this module.