### PR TITLE
Transactions API 

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -87,7 +87,7 @@ class Info extends ConfigurableInfo
     protected function getLoanId()
     {
         return $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('transaction_id')
-            ?? $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('charge_id');
+            ?: $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('charge_id');
     }
 
     /**

--- a/Block/Info.php
+++ b/Block/Info.php
@@ -80,13 +80,24 @@ class Info extends ConfigurableInfo
     }
 
     /**
+     * Get Loan ID
+     *
+     * @return string
+     */
+    protected function getLoanId()
+    {
+        return $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('transaction_id')
+            ?? $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('charge_id');
+    }
+
+    /**
      * Get admin affirm URL
      *
      * @return string
      */
     protected function getAdminAffirmUrl()
     {
-        $loanId = $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('charge_id');
+        $loanId = $this->getLoanId();
         return sprintf('https://%s/dashboard/#/details/%s?trk=%s', $this->getDomainUrl(), $loanId,
             $this->getPublicApiKey()
         );
@@ -99,7 +110,7 @@ class Info extends ConfigurableInfo
      */
     protected function getFrontendAffirmUrl()
     {
-        $loanId = $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('charge_id');
+        $loanId = $this->getLoanId();
         return sprintf("https://%s/u/#/loans/%s?trk=%s", $this->getDomainUrl(), $loanId, $this->getPublicApiKey());
     }
 

--- a/Gateway/Command/CaptureStrategyCommand.php
+++ b/Gateway/Command/CaptureStrategyCommand.php
@@ -37,6 +37,7 @@ class CaptureStrategyCommand implements CommandInterface
     const ORDER_CAPTURE = 'order_capture';
     const CHECKOUT_TOKEN = 'checkout_token';
     const TRANSACTION_ID = 'transaction_id';
+    const CHARGE_ID = 'charge_id';
     /**#@-*/
 
     /**
@@ -71,7 +72,8 @@ class CaptureStrategyCommand implements CommandInterface
 
         /** @var Order\Payment $paymentInfo */
         $paymentInfo = $paymentDO->getPayment();
-        $transactionId = $paymentInfo->getAdditionalInformation(self::TRANSACTION_ID);
+        $transactionId = $paymentInfo->getAdditionalInformation(self::TRANSACTION_ID) ?:
+            $paymentInfo->getAdditionalInformation(self::CHARGE_ID);
         if (($paymentInfo instanceof Order\Payment) && !$transactionId) {
             $checkoutToken = $paymentInfo->getAdditionalInformation(self::CHECKOUT_TOKEN);
             if ($checkoutToken) {

--- a/Gateway/Command/CaptureStrategyCommand.php
+++ b/Gateway/Command/CaptureStrategyCommand.php
@@ -36,6 +36,7 @@ class CaptureStrategyCommand implements CommandInterface
     const AUTHORIZE = 'authorize';
     const ORDER_CAPTURE = 'order_capture';
     const CHECKOUT_TOKEN = 'checkout_token';
+    const TRANSACTION_ID = 'transaction_id';
     /**#@-*/
 
     /**
@@ -70,8 +71,8 @@ class CaptureStrategyCommand implements CommandInterface
 
         /** @var Order\Payment $paymentInfo */
         $paymentInfo = $paymentDO->getPayment();
-        $chargeId = $paymentInfo->getAdditionalInformation('charge_id');
-        if (($paymentInfo instanceof Order\Payment) && !$chargeId) {
+        $transactionId = $paymentInfo->getAdditionalInformation(self::TRANSACTION_ID);
+        if (($paymentInfo instanceof Order\Payment) && !$transactionId) {
             $checkoutToken = $paymentInfo->getAdditionalInformation(self::CHECKOUT_TOKEN);
             if ($checkoutToken) {
                 $this->commandPool

--- a/Gateway/Helper/Request/Action.php
+++ b/Gateway/Helper/Request/Action.php
@@ -28,7 +28,7 @@ class Action
     /**#@+
      * Define constants
      */
-    const API_CHARGES_PATH = '/api/v2/charges/';
+    const API_TRANSACTIONS_PATH = '/api/v1/transactions/';
     const API_CHECKOUT_PATH = '/api/v2/checkout/';
     /**#@-*/
 

--- a/Gateway/Http/Client/ClientService.php
+++ b/Gateway/Http/Client/ClientService.php
@@ -39,13 +39,6 @@ class ClientService implements ClientInterface
     /**#@-*/
 
     /**
-     * Request URI
-     *
-     * @var string
-     */
-    private static $requestUri;
-
-    /**
      * Logger
      *
      * @var Logger
@@ -103,11 +96,11 @@ class ClientService implements ClientInterface
     {
         $log = [];
         $response = [];
+        $requestUri = trim($transferObject->getUri(), '/');
         try {
             /** @var \Magento\Framework\HTTP\ZendClient $client */
             $client = $this->httpClientFactory->create();
-            self::$requestUri = trim($transferObject->getUri(), '/');
-            $client->setUri(self::$requestUri);
+            $client->setUri($requestUri);
             $client->setAuth($transferObject->getAuthUsername(), $transferObject->getAuthPassword());
             if (!empty($transferObject->getBody())) {
                 $data = $transferObject->getBody();
@@ -123,7 +116,7 @@ class ClientService implements ClientInterface
             $this->logger->error($log);
             throw new ClientException(__($e->getMessage()));
         } finally {
-            $log['uri'] = self::$requestUri;
+            $log['uri'] = $requestUri;
             $log['response'] = $response;
             $this->logger->debug($log);
             $this->affirmLogger->debug('Astound\Affirm\Gateway\Http\Client\ClientService::placeRequest', $log);

--- a/Gateway/Http/Client/ClientService.php
+++ b/Gateway/Http/Client/ClientService.php
@@ -95,12 +95,13 @@ class ClientService implements ClientInterface
     public function placeRequest(TransferInterface $transferObject)
     {
         $log = [];
-        $log['uri'] = $transferObject->getUri();
         $response = [];
+        $_requestUri = '';
         try {
             /** @var \Magento\Framework\HTTP\ZendClient $client */
             $client = $this->httpClientFactory->create();
-            $client->setUri($transferObject->getUri());
+            $_requestUri = trim($transferObject->getUri(), '/');
+            $client->setUri($_requestUri);
             $client->setAuth($transferObject->getAuthUsername(), $transferObject->getAuthPassword());
             if (!empty($transferObject->getBody())) {
                 $data = $transferObject->getBody();
@@ -116,6 +117,7 @@ class ClientService implements ClientInterface
             $this->logger->error($log);
             throw new ClientException(__($e->getMessage()));
         } finally {
+            $log['uri'] = $_requestUri;
             $log['response'] = $response;
             $this->logger->debug($log);
             $this->affirmLogger->debug('Astound\Affirm\Gateway\Http\Client\ClientService::placeRequest', $log);

--- a/Gateway/Http/Client/ClientService.php
+++ b/Gateway/Http/Client/ClientService.php
@@ -39,6 +39,13 @@ class ClientService implements ClientInterface
     /**#@-*/
 
     /**
+     * Request URI
+     *
+     * @var string
+     */
+    private static $requestUri;
+
+    /**
      * Logger
      *
      * @var Logger
@@ -96,12 +103,11 @@ class ClientService implements ClientInterface
     {
         $log = [];
         $response = [];
-        $_requestUri = '';
         try {
             /** @var \Magento\Framework\HTTP\ZendClient $client */
             $client = $this->httpClientFactory->create();
-            $_requestUri = trim($transferObject->getUri(), '/');
-            $client->setUri($_requestUri);
+            self::$requestUri = trim($transferObject->getUri(), '/');
+            $client->setUri(self::$requestUri);
             $client->setAuth($transferObject->getAuthUsername(), $transferObject->getAuthPassword());
             if (!empty($transferObject->getBody())) {
                 $data = $transferObject->getBody();
@@ -117,7 +123,7 @@ class ClientService implements ClientInterface
             $this->logger->error($log);
             throw new ClientException(__($e->getMessage()));
         } finally {
-            $log['uri'] = $_requestUri;
+            $log['uri'] = self::$requestUri;
             $log['response'] = $response;
             $this->logger->debug($log);
             $this->affirmLogger->debug('Astound\Affirm\Gateway\Http\Client\ClientService::placeRequest', $log);

--- a/Gateway/Request/AbstractDataBuilder.php
+++ b/Gateway/Request/AbstractDataBuilder.php
@@ -30,7 +30,7 @@ abstract class AbstractDataBuilder implements BuilderInterface
      * Define constants
      */
     const CHECKOUT_TOKEN = 'checkout_token';
-    const CHARGE_ID = 'charge_id';
+    const TRANSACTION_ID = 'transaction_id';
     /**#@-*/
 
     /**

--- a/Gateway/Request/AbstractDataBuilder.php
+++ b/Gateway/Request/AbstractDataBuilder.php
@@ -31,6 +31,7 @@ abstract class AbstractDataBuilder implements BuilderInterface
      */
     const CHECKOUT_TOKEN = 'checkout_token';
     const TRANSACTION_ID = 'transaction_id';
+    const CHARGE_ID = 'charge_id';
     /**#@-*/
 
     /**

--- a/Gateway/Request/AuthorizationRequest.php
+++ b/Gateway/Request/AuthorizationRequest.php
@@ -46,7 +46,7 @@ class AuthorizationRequest extends AbstractDataBuilder
         $token = $payment->getAdditionalInformation(self::CHECKOUT_TOKEN);
         return [
             'body' => [
-                self::CHECKOUT_TOKEN => $token
+                self::TRANSACTION_ID => $token
             ],
             'path' => ''
         ];

--- a/Gateway/Request/CaptureRequest.php
+++ b/Gateway/Request/CaptureRequest.php
@@ -43,7 +43,7 @@ class CaptureRequest extends AbstractDataBuilder
         /** @var PaymentDataObjectInterface $payment */
         $paymentDataObject = $buildSubject['payment'];
         $payment = $paymentDataObject->getPayment();
-        $chargeId = $payment->getAdditionalInformation(self::CHARGE_ID);
+        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID);
         $order = $payment->getOrder();
         if($order) {
             $storeId = $order->getStoreId();
@@ -53,7 +53,7 @@ class CaptureRequest extends AbstractDataBuilder
         }
         return [
             'body' => [],
-            'path' => "{$chargeId}/capture",
+            'path' => "{$transactionId}/capture",
             'storeId' => $storeId
         ];
     }

--- a/Gateway/Request/CaptureRequest.php
+++ b/Gateway/Request/CaptureRequest.php
@@ -43,7 +43,8 @@ class CaptureRequest extends AbstractDataBuilder
         /** @var PaymentDataObjectInterface $payment */
         $paymentDataObject = $buildSubject['payment'];
         $payment = $paymentDataObject->getPayment();
-        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID);
+        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID) ?:
+            $payment->getAdditionalInformation(self::CHARGE_ID);
         $order = $payment->getOrder();
         if($order) {
             $storeId = $order->getStoreId();

--- a/Gateway/Request/RefundRequest.php
+++ b/Gateway/Request/RefundRequest.php
@@ -44,7 +44,7 @@ class RefundRequest extends AbstractDataBuilder
         /** @var PaymentDataObjectInterface $payment */
         $paymentDataObject = $buildSubject['payment'];
         $payment = $paymentDataObject->getPayment();
-        $chargeId = $payment->getAdditionalInformation(self::CHARGE_ID);
+        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID);
         $amountInCents = Util::formatToCents($buildSubject['amount']);
         $order = $payment->getOrder();
         if($order) {
@@ -57,7 +57,7 @@ class RefundRequest extends AbstractDataBuilder
             'body' => [
                 'amount' => $amountInCents
             ],
-            'path' => "{$chargeId}/refund",
+            'path' => "{$transactionId}/refund",
             'storeId' => $storeId
         ];
     }

--- a/Gateway/Request/RefundRequest.php
+++ b/Gateway/Request/RefundRequest.php
@@ -44,7 +44,8 @@ class RefundRequest extends AbstractDataBuilder
         /** @var PaymentDataObjectInterface $payment */
         $paymentDataObject = $buildSubject['payment'];
         $payment = $paymentDataObject->getPayment();
-        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID);
+        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID) ?:
+            $payment->getAdditionalInformation(self::CHARGE_ID);
         $amountInCents = Util::formatToCents($buildSubject['amount']);
         $order = $payment->getOrder();
         if($order) {

--- a/Gateway/Request/VoidRequest.php
+++ b/Gateway/Request/VoidRequest.php
@@ -43,7 +43,7 @@ class VoidRequest extends AbstractDataBuilder
         /** @var PaymentDataObjectInterface $payment */
         $paymentDataObject = $buildSubject['payment'];
         $payment = $paymentDataObject->getPayment();
-        $chargeId = $payment->getAdditionalInformation(self::CHARGE_ID);
+        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID);
         $order = $payment->getOrder();
         if($order) {
             $storeId = $order->getStoreId();
@@ -53,7 +53,7 @@ class VoidRequest extends AbstractDataBuilder
         }
         return [
             'body' => [],
-            'path' => "{$chargeId}/void",
+            'path' => "{$transactionId}/void",
             'storeId' => $storeId
         ];
     }

--- a/Gateway/Request/VoidRequest.php
+++ b/Gateway/Request/VoidRequest.php
@@ -43,7 +43,8 @@ class VoidRequest extends AbstractDataBuilder
         /** @var PaymentDataObjectInterface $payment */
         $paymentDataObject = $buildSubject['payment'];
         $payment = $paymentDataObject->getPayment();
-        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID);
+        $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID) ?:
+            $payment->getAdditionalInformation(self::CHARGE_ID);
         $order = $payment->getOrder();
         if($order) {
             $storeId = $order->getStoreId();

--- a/Gateway/Response/TransactionAuthorizeHandler.php
+++ b/Gateway/Response/TransactionAuthorizeHandler.php
@@ -30,8 +30,8 @@ class TransactionAuthorizeHandler implements HandlerInterface
     /**#@+
      * Define constants
      */
-    const TRANSACTION_ID = 'id';
-    const CHARGE_ID = 'charge_id';
+    const TRANSACTION_OBJECT_ID = 'id';
+    const TRANSACTION_ID = 'transaction_id';
     /**#@-*/
 
     /**
@@ -42,8 +42,8 @@ class TransactionAuthorizeHandler implements HandlerInterface
         $paymentDO = SubjectReader::readPayment($handlingSubject);
         /** @var Payment $orderPayment */
         $orderPayment = $paymentDO->getPayment();
-        $orderPayment->setAdditionalInformation(self::CHARGE_ID, $response[self::TRANSACTION_ID]);
-        $orderPayment->setTransactionId($response[self::TRANSACTION_ID]);
+        $orderPayment->setAdditionalInformation(self::TRANSACTION_ID, $response[self::TRANSACTION_OBJECT_ID]);
+        $orderPayment->setTransactionId($response[self::TRANSACTION_OBJECT_ID]);
         $orderPayment->setIsTransactionClosed(false);
     }
 }

--- a/Gateway/Response/TransactionRefundHandler.php
+++ b/Gateway/Response/TransactionRefundHandler.php
@@ -32,7 +32,7 @@ class TransactionRefundHandler implements HandlerInterface
     /**#@+
      * Define constants
      */
-    const CHARGE_ID = 'charge_id';
+    const TRANSACTION_ID = 'transaction_id';
     /**#@-*/
 
     /**
@@ -64,9 +64,9 @@ class TransactionRefundHandler implements HandlerInterface
         $id = $this->localeDate->date()
             ->format('His');
         $id = ($id) ? $id : 1;
-        $chargeId = $orderPayment->getAdditionalInformation(self::CHARGE_ID);
+        $transactionId = $orderPayment->getAdditionalInformation(self::TRANSACTION_ID);
         $type = Transaction::TYPE_REFUND;
-        $orderPayment->setTransactionId("{$chargeId}-{$id}-{$type}");
+        $orderPayment->setTransactionId("{$transactionId}-{$id}-{$type}");
         $orderPayment->setIsTransactionClosed(true);
     }
 }

--- a/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
+++ b/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
@@ -34,8 +34,8 @@ class AfterShipmentSaveObserver implements ObserverInterface
     /**#@+
      * Define constants
      */
-    const CHARGE_ID = 'charge_id';
-    const API_CHARGES_PATH = '/api/v2/charges/';
+    const TRANSACTION_ID = 'transaction_id';
+    const API_TRANSACTIONS_PATH = '/api/v1/transactions/';
     /**#@-*/
 
     /**
@@ -110,9 +110,9 @@ class AfterShipmentSaveObserver implements ObserverInterface
             $shippingCarrier = implode(',', $carriers);
             $shippingConfirmation = implode(',', $confirmation);
             $orderIncrementId = $order->getIncrementId();
-            $chargeId = $order->getPayment()->getAdditionalInformation(self::CHARGE_ID);
+            $transactionId = $order->getPayment()->getAdditionalInformation(self::TRANSACTION_ID);
 
-            $url = $this->getApiUrl("{$chargeId}/update");
+            $url = $this->getApiUrl("{$transactionId}");
             $data = [
                 'order_id' => $orderIncrementId,
                 'shipping_carrier' => $shippingCarrier,
@@ -183,6 +183,6 @@ class AfterShipmentSaveObserver implements ObserverInterface
             ? \Astound\Affirm\Model\Config::API_URL_SANDBOX
             : \Astound\Affirm\Model\Config::API_URL_PRODUCTION;
 
-        return trim($gateway, '/') . sprintf('%s%s', self::API_CHARGES_PATH, $additionalPath);
+        return trim($gateway, '/') . sprintf('%s%s', self::API_TRANSACTIONS_PATH, $additionalPath);
     }
 }

--- a/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
+++ b/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
@@ -35,6 +35,7 @@ class AfterShipmentSaveObserver implements ObserverInterface
      * Define constants
      */
     const TRANSACTION_ID = 'transaction_id';
+    const CHARGE_ID = 'charge_id';
     const API_TRANSACTIONS_PATH = '/api/v1/transactions/';
     /**#@-*/
 
@@ -110,7 +111,8 @@ class AfterShipmentSaveObserver implements ObserverInterface
             $shippingCarrier = implode(',', $carriers);
             $shippingConfirmation = implode(',', $confirmation);
             $orderIncrementId = $order->getIncrementId();
-            $transactionId = $order->getPayment()->getAdditionalInformation(self::TRANSACTION_ID);
+            $transactionId = $order->getPayment()->getAdditionalInformation(self::TRANSACTION_ID) ?:
+                $order->getPayment()->getAdditionalInformation(self::CHARGE_ID);
 
             $url = $this->getApiUrl("{$transactionId}");
             $data = [

--- a/Model/Plugin/Order/AddressSave/Edit.php
+++ b/Model/Plugin/Order/AddressSave/Edit.php
@@ -30,8 +30,8 @@ use Astound\Affirm\Logger\Logger;
  */
 class Edit
 {
-    const CHARGE_ID = 'charge_id';
-    const API_CHARGES_PATH = '/api/v2/charges/';
+    const TRANSACTION_ID = 'transaction_id';
+    const API_TRANSACTIONS_PATH = '/api/v1/transactions/';
 
 
     /**
@@ -100,10 +100,10 @@ class Edit
 
             $order = $orderCollection->getFirstItem();
         if ($this->isAffirmPaymentMethod($order)) {
-            $chargeId = $order->getPayment()->getAdditionalInformation(self::CHARGE_ID);
+            $transactionId = $order->getPayment()->getAdditionalInformation(self::TRANSACTION_ID);
             $newAddress = $order->getShippingAddress()->getData();
             $street = explode(PHP_EOL, $newAddress['street']);
-            $url = $this->getApiUrl("{$chargeId}/update");
+            $url = $this->getApiUrl("{$transactionId}");
             $data = array(
                 'shipping' => array(
                     'name' => array(
@@ -149,7 +149,7 @@ class Edit
             ? \Astound\Affirm\Model\Config::API_URL_SANDBOX
             : \Astound\Affirm\Model\Config::API_URL_PRODUCTION;
 
-        return trim($gateway, '/') . sprintf('%s%s', self::API_CHARGES_PATH, $additionalPath);
+        return trim($gateway, '/') . sprintf('%s%s', self::API_TRANSACTIONS_PATH, $additionalPath);
     }
 
     protected function isAffirmPaymentMethod($order)

--- a/Model/Plugin/Order/AddressSave/Edit.php
+++ b/Model/Plugin/Order/AddressSave/Edit.php
@@ -31,6 +31,7 @@ use Astound\Affirm\Logger\Logger;
 class Edit
 {
     const TRANSACTION_ID = 'transaction_id';
+    const CHARGE_ID = 'charge_id';
     const API_TRANSACTIONS_PATH = '/api/v1/transactions/';
 
 
@@ -100,7 +101,8 @@ class Edit
 
             $order = $orderCollection->getFirstItem();
         if ($this->isAffirmPaymentMethod($order)) {
-            $transactionId = $order->getPayment()->getAdditionalInformation(self::TRANSACTION_ID);
+            $transactionId = $order->getPayment()->getAdditionalInformation(self::TRANSACTION_ID) ?:
+                $order->getPayment()->getAdditionalInformation(self::CHARGE_ID);
             $newAddress = $order->getShippingAddress()->getData();
             $street = explode(PHP_EOL, $newAddress['street']);
             $url = $this->getApiUrl("{$transactionId}");

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -246,7 +246,7 @@
 
     <virtualType name="AffirmClientTransactionAction" type="Astound\Affirm\Gateway\Helper\Request\Action">
         <arguments>
-            <argument name="action" xsi:type="const">Astound\Affirm\Gateway\Helper\Request\Action::API_CHARGES_PATH</argument>
+            <argument name="action" xsi:type="const">Astound\Affirm\Gateway\Helper\Request\Action::API_TRANSACTIONS_PATH</argument>
         </arguments>
     </virtualType>
     <!-- Authorization Transfer Factory -->

--- a/view/frontend/web/js/affirmPixel.js
+++ b/view/frontend/web/js/affirmPixel.js
@@ -76,4 +76,4 @@ define([
     });
 
     return $.mage.affirmPixel
-});;
+});


### PR DESCRIPTION
### Description
Allowing Magento 2 extension to use [Transactions API](https://docs.affirm.com/affirm-developers/reference#merchant-transactions-api) which replaces the existing [Charges endpoints](https://docs.affirm.com/affirm-developers/reference#the-charge-object) while maintaining the same functionality. 

### Summary of changes
* Changed request URI paths for charge related actions (`api/v2/charges` -> `api/v1/transactions`) along with other parameter changes to use the Transactions API
* Updated references of `charge_id` variable name to `transaction_id` 
* Allow previous stored `charge_id` payment attribute to be accessible to maintain backward compatibilit

### How to test
Place an order using Affirm payment and perform charge actions in admin mode (capture, void, update, refund, etc). Using developer mode, confirm the updated endpoint in the uri attribute within `affirm.log`.

### Benefits
Adds support to use the new Transactions API.