### PR TITLE
Prevent JS error in an empty cart

### DIFF
--- a/view/frontend/web/js/affirmPixel.js
+++ b/view/frontend/web/js/affirmPixel.js
@@ -58,8 +58,9 @@ define([
 
             function sendTracker(options){
                 affirm.ui.ready(function(){
-
-                    affirm.analytics[options.method](options.parameter[0], options.parameter[1], options.parameter[2]);
+                    if( options.method && options.parameter ) {
+                        affirm.analytics[options.method](options.parameter[0], options.parameter[1], options.parameter[2]);
+                    }
                 });
             }
 


### PR DESCRIPTION
---
name: PR Template
---

### Description
<!--- Describe the Bug/feature/enhancement you are adding in this PR. -->
A javascript error is thrown when visiting an empty cart page.
"Uncaught TypeError: Cannot read properties of undefined (reading '0')"


### How To Reproduce
Steps to reproduce the behavior:
1. Go to the cart page with no products in the cart
2. See error in the browsers developer tools console tab

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->
No error thrown

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->
Reduces white-noise errors that are thrown thus making it easier for developers to focus on errors that matter.  Also is good practice to write good code.

### Additional information
<!--- What other information can you provide about the bug/feature? -->
