### PR TITLE
Store level API keys

### DIFF
--- a/Gateway/Helper/Request/Action.php
+++ b/Gateway/Helper/Request/Action.php
@@ -52,8 +52,10 @@ class Action
      * @param string $action
      * @param ConfigInterface $config
      */
-    public function __construct($action, ConfigInterface $config)
-    {
+    public function __construct(
+        $action,
+        ConfigInterface $config
+    ) {
         $this->action = $action;
         $this->config = $config;
     }
@@ -64,9 +66,9 @@ class Action
      * @param string $additionalPath
      * @return string
      */
-    public function getUrl($additionalPath = '')
+    public function getUrl($additionalPath = '', $storeId = null)
     {
-        $gateway = $this->config->getValue('mode') == 'sandbox'
+        $gateway = $this->config->getValue('mode', $storeId) == 'sandbox'
             ? \Astound\Affirm\Model\Config::API_URL_SANDBOX
             : \Astound\Affirm\Model\Config::API_URL_PRODUCTION;
 

--- a/Gateway/Http/AbstractTransferFactory.php
+++ b/Gateway/Http/AbstractTransferFactory.php
@@ -22,6 +22,7 @@ use Astound\Affirm\Gateway\Helper\Request\Action;
 use Magento\Payment\Gateway\ConfigInterface;
 use Magento\Payment\Gateway\Http\TransferBuilder;
 use Magento\Payment\Gateway\Http\TransferFactoryInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class AbstractTransferFactory
@@ -50,6 +51,13 @@ abstract class AbstractTransferFactory implements TransferFactoryInterface
     protected $action;
 
     /**
+     * Store manager
+     *
+     * @var \Magento\Store\App\Model\StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
      * Construct
      *
      * @param ConfigInterface $config
@@ -59,11 +67,13 @@ abstract class AbstractTransferFactory implements TransferFactoryInterface
     public function __construct(
         ConfigInterface $config,
         TransferBuilder $transferBuilder,
-        Action $action
+        Action $action,
+        StoreManagerInterface $storeManager
     ) {
         $this->config = $config;
         $this->transferBuilder = $transferBuilder;
         $this->action = $action;
+        $this->_storeManager = $storeManager;
     }
 
     /**
@@ -103,5 +113,15 @@ abstract class AbstractTransferFactory implements TransferFactoryInterface
                 ? $this->config->getValue('private_api_key_sandbox')
                 : $this->config->getValue('private_api_key_production');
         }
+    }
+
+    /**
+     * Get store id
+     *
+     * @return string
+     */
+    protected function getStoreId()
+    {
+        return $this->_storeManager->getStore()->getId();
     }
 }

--- a/Gateway/Http/AbstractTransferFactory.php
+++ b/Gateway/Http/AbstractTransferFactory.php
@@ -75,7 +75,7 @@ abstract class AbstractTransferFactory implements TransferFactoryInterface
     protected function getPublicApiKey($storeId)
     {
         if(!empty($storeId)){
-            return $this->config->getValue('mode') == 'sandbox'
+            return $this->config->getValue('mode', $storeId) == 'sandbox'
                 ? $this->config->getValue('public_api_key_sandbox', $storeId)
                 : $this->config->getValue('public_api_key_production', $storeId);
         } else {
@@ -95,7 +95,7 @@ abstract class AbstractTransferFactory implements TransferFactoryInterface
     protected function getPrivateApiKey($storeId)
     {
         if(!empty($storeId)){
-            return $this->config->getValue('mode') == 'sandbox'
+            return $this->config->getValue('mode', $storeId) == 'sandbox'
                 ? $this->config->getValue('private_api_key_sandbox', $storeId)
                 : $this->config->getValue('private_api_key_production', $storeId);
         } else {

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -35,14 +35,14 @@ class TransferFactory extends AbstractTransferFactory
     public function create(array $request)
     {
         $method = isset($request['method']) ? $request['method'] : ClientService::POST;
-        $storeId = isset($request['storeId']) ? $request['storeId'] : '';
+        $storeId = $this->getStoreId();
         return $this->transferBuilder
             ->setMethod($method)
             ->setHeaders(['Content-Type' => 'application/json'])
             ->setBody($request['body'])
             ->setAuthUsername($this->getPublicApiKey($storeId))
             ->setAuthPassword($this->getPrivateApiKey($storeId))
-            ->setUri($this->getApiUrl($request['path']))
+            ->setUri($this->getApiUrl($request['path'], $storeId))
             ->build();
     }
 
@@ -50,10 +50,11 @@ class TransferFactory extends AbstractTransferFactory
      * Get Api url
      *
      * @param string $additionalPath
+     * @param string $storeId
      * @return string
      */
-    protected function getApiUrl($additionalPath)
+    protected function getApiUrl($additionalPath, $storeId)
     {
-        return $this->action->getUrl($additionalPath);
+        return $this->action->getUrl($additionalPath, $storeId);
     }
 }

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -35,7 +35,8 @@ class TransferFactory extends AbstractTransferFactory
     public function create(array $request)
     {
         $method = isset($request['method']) ? $request['method'] : ClientService::POST;
-        $storeId = $this->getStoreId();
+        // Admin actions will include store id in the request
+        $storeId = isset($request['storeId']) ? $request['storeId'] : $this->getStoreId();
         return $this->transferBuilder
             ->setMethod($method)
             ->setHeaders(['Content-Type' => 'application/json'])

--- a/Gateway/Request/AbstractDataBuilder.php
+++ b/Gateway/Request/AbstractDataBuilder.php
@@ -20,6 +20,7 @@ namespace Astound\Affirm\Gateway\Request;
 
 use Magento\Payment\Gateway\ConfigInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class AbstractDataBuilder
@@ -42,13 +43,20 @@ abstract class AbstractDataBuilder implements BuilderInterface
     private $config;
 
     /**
+     * Store manager
+     *
+     * @var \Magento\Store\App\Model\StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
      * Constructor
      *
      * @param ConfigInterface $config
      */
     public function __construct(
         ConfigInterface $config,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager
     ) {
         $this->config = $config;
         $this->_storeManager = $storeManager;

--- a/Gateway/Request/AbstractDataBuilder.php
+++ b/Gateway/Request/AbstractDataBuilder.php
@@ -47,9 +47,11 @@ abstract class AbstractDataBuilder implements BuilderInterface
      * @param ConfigInterface $config
      */
     public function __construct(
-        ConfigInterface $config
+        ConfigInterface $config,
+        \Magento\Store\Model\StoreManagerInterface $storeManager
     ) {
         $this->config = $config;
+        $this->_storeManager = $storeManager;
     }
 
     /**

--- a/Gateway/Request/CaptureRequest.php
+++ b/Gateway/Request/CaptureRequest.php
@@ -46,9 +46,7 @@ class CaptureRequest extends AbstractDataBuilder
         $transactionId = $payment->getAdditionalInformation(self::TRANSACTION_ID) ?:
             $payment->getAdditionalInformation(self::CHARGE_ID);
         $order = $payment->getOrder();
-        if($order) {
-            $storeId = $this->_storeManager->getStore()->getId();
-        }
+        $storeId = isset($order) ? $order->getStoreId() : $this->_storeManager->getStore()->getId();
         if (!$storeId) {
             $storeId = null;
         }

--- a/Gateway/Request/CaptureRequest.php
+++ b/Gateway/Request/CaptureRequest.php
@@ -47,7 +47,7 @@ class CaptureRequest extends AbstractDataBuilder
             $payment->getAdditionalInformation(self::CHARGE_ID);
         $order = $payment->getOrder();
         if($order) {
-            $storeId = $order->getStoreId();
+            $storeId = $this->_storeManager->getStore()->getId();
         }
         if (!$storeId) {
             $storeId = null;

--- a/Helper/Pixel.php
+++ b/Helper/Pixel.php
@@ -36,6 +36,7 @@
 namespace Astound\Affirm\Helper;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Astound\Affirm\Model\Config as Config;
 
 /**
@@ -53,6 +54,13 @@ class Pixel
     protected $scopeConfig;
 
     /**
+     * Store manager
+     *
+     * @var \Magento\Store\App\Model\StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
      * Init
      *
      * @param ScopeConfigInterface $scopeConfig
@@ -60,9 +68,11 @@ class Pixel
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
+        StoreManagerInterface $storeManager,
         Config $configAffirm
     ) {
         $this->scopeConfig = $scopeConfig;
+        $this->_storeManager = $storeManager;
         $this->affirmPaymentConfig = $configAffirm;
     }
 
@@ -120,5 +130,15 @@ class Pixel
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $scope
         );
+    }
+
+    /**
+     * Get store id
+     *
+     * @return int
+     */
+    protected function getStoreId()
+    {
+        return $this->_storeManager->getStore()->getId();
     }
 }

--- a/Model/Plugin/Order/AddressSave/Edit.php
+++ b/Model/Plugin/Order/AddressSave/Edit.php
@@ -23,6 +23,8 @@ use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Astound\Affirm\Model\Ui\ConfigProvider;
 use Magento\Framework\HTTP\ZendClientFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\ScopeInterface;
 use Astound\Affirm\Logger\Logger;
 
 /**
@@ -63,6 +65,13 @@ class Edit
     protected $scopeConfig;
 
     /**
+     * Store manager
+     *
+     * @var \Magento\Store\App\Model\StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
      * Affirm logging instance
      *
      * @var \Astound\Affirm\Logger\Logger
@@ -73,11 +82,13 @@ class Edit
         CollectionFactory $collectionFactory,
         ZendClientFactory $httpClientFactory,
         ScopeConfigInterface $scopeConfig,
+        StoreManagerInterface $storeManager,
         Logger $logger
     ) {
         $this->_collectionFactory = $collectionFactory;
         $this->httpClientFactory = $httpClientFactory;
         $this->scopeConfig = $scopeConfig;
+        $this->_storeManager = $storeManager;
         $this->logger = $logger;
     }
 
@@ -147,7 +158,7 @@ class Edit
 
     protected function getApiUrl($additionalPath)
     {
-        $gateway = $this->scopeConfig->getValue('payment/affirm_gateway/mode') == 'sandbox'
+        $gateway = $this->getIsSandboxMode()
             ? \Astound\Affirm\Model\Config::API_URL_SANDBOX
             : \Astound\Affirm\Model\Config::API_URL_PRODUCTION;
 
@@ -161,9 +172,9 @@ class Edit
 
     protected function getPrivateApiKey()
     {
-        return $this->scopeConfig->getValue('payment/affirm_gateway/mode') == 'sandbox'
-            ? $this->scopeConfig->getValue('payment/affirm_gateway/private_api_key_sandbox')
-            : $this->scopeConfig->getValue('payment/affirm_gateway/private_api_key_production');
+        return $this->getIsSandboxMode()
+            ? $this->scopeConfig->getValue('payment/affirm_gateway/private_api_key_sandbox', ScopeInterface::SCOPE_STORE, $this->getStoreId())
+            : $this->scopeConfig->getValue('payment/affirm_gateway/private_api_key_production', ScopeInterface::SCOPE_STORE, $this->getStoreId());
     }
 
     /**
@@ -173,8 +184,28 @@ class Edit
      */
     protected function getPublicApiKey()
     {
-        return $this->scopeConfig->getValue('payment/affirm_gateway/mode') == 'sandbox'
-            ? $this->scopeConfig->getValue('payment/affirm_gateway/public_api_key_sandbox')
-            : $this->scopeConfig->getValue('payment/affirm_gateway/public_api_key_production');
+        return $this->getIsSandboxMode()
+            ? $this->scopeConfig->getValue('payment/affirm_gateway/public_api_key_sandbox', ScopeInterface::SCOPE_STORE, $this->getStoreId())
+            : $this->scopeConfig->getValue('payment/affirm_gateway/public_api_key_production', ScopeInterface::SCOPE_STORE, $this->getStoreId());
+    }
+
+    /**
+     * Get is sandbox mode
+     *
+     * @return boolean
+     */
+    protected function getIsSandboxMode()
+    {
+        return $this->scopeConfig->getValue('payment/affirm_gateway/mode', ScopeInterface::SCOPE_STORE, $this->getStoreId()) == 'sandbox';
+    }
+
+    /**
+     * Get store id
+     *
+     * @return string
+     */
+    protected function getStoreId()
+    {
+        return $this->_storeManager->getStore()->getId();
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -44,31 +44,31 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="mode" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="mode" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Mode</label>
                     <source_model>Astound\Affirm\Model\Adminhtml\Source\ModeAction</source_model>
                 </field>
-                <field id="public_api_key_sandbox" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="public_api_key_sandbox" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Public API Key</label>
-                    <depends><field id="mode">sandbox</field></depends>
+                    <depends><field id="*/*/mode">sandbox</field></depends>
                 </field>
-                <field id="private_api_key_sandbox" translate="label" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="private_api_key_sandbox" translate="label" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Private API Key</label>
                     <config_path>payment/affirm_gateway/private_api_key_sandbox</config_path>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     <attribute type="shared">1</attribute>
-                    <depends><field id="mode">sandbox</field></depends>
+                    <depends><field id="*/*/mode">sandbox</field></depends>
                 </field>
-                <field id="public_api_key_production" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="public_api_key_production" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Public API Key</label>
                     <config_path>payment/affirm_gateway/public_api_key_production</config_path>
-                    <depends><field id="mode">production</field></depends>
+                    <depends><field id="*/*/mode">production</field></depends>
                 </field>
-                <field id="private_api_key_production" translate="label" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="private_api_key_production" translate="label" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Private API Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     <attribute type="shared">1</attribute>
-                    <depends><field id="mode">production</field></depends>
+                    <depends><field id="*/*/mode">production</field></depends>
                 </field>
                 <field id="payment_action" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Payment Action</label>


### PR DESCRIPTION
---
Store level API keys
---

### Description
Allow Affirm API credentials to be configured on the store level scope instead of being set within the default configuration only.

### How To Test
Steps to test the proposed changes:
1. Go to Admin Stores -> Configuration
2. Click on Scope dropdown to access substores
3. Scroll down to Sales -> Payment methods -> Affirm
4. Uncheck "Use Website" next to API keys and mode inputs to configure 

### Screenshots

![Screen Shot 2021-10-25 at 10 58 12 PM](https://user-images.githubusercontent.com/9426310/138817454-6a959319-61b6-452e-bbda-e602c76a01dd.png)

