### PR TITLE
Uninstall script

### DIFF
--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -66,36 +66,18 @@ class Uninstall implements UninstallInterface
 
         /** @var EavSetup $eavSetup */
         $eavSetup = $this->eavSetupFactory->create(['setup' => $this->setup]);
-
-		if (version_compare($context->getVersion(), '0.4.2', '<')) {
-			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp');
-			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp');
-		}
-
-		if (version_compare($context->getVersion(), '0.4.3', '<')) {
-			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_type');
-			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_priority');
-			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_type');
-			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_priority');
-		}
-
-		if (version_compare($context->getVersion(), '1.0.2', '<')) {
-			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_start_date');
-			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_end_date');
-			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_start_date');
-			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_end_date');
-		}
-
-		if (version_compare($context->getVersion(), '1.0.3', '<')) {
-			$eavSetup->removeAttribute(
-                \Magento\Catalog\Model\Category::ENTITY,
-                'affirm_category_promo_id',
-            );
-			$eavSetup->removeAttribute(
-                \Magento\Catalog\Model\Product::ENTITY,
-                'affirm_product_promo_id',
-            );
-		}
+		$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp');
+		$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp');
+		$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_type');
+		$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_priority');
+		$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_type');
+		$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_priority');
+		$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_start_date');
+		$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_end_date');
+		$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_start_date');
+		$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_end_date');
+		$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_promo_id');
+		$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_promo_id');
 
 		// Drop tables
 		$schemaSetup->startSetup();

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @category  Affirm
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Astound\Affirm\Setup;
+
+use Magento\Customer\Setup\CustomerSetupFactory;
+use Magento\Customer\Model\Customer;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Category;
+use Magento\Eav\Setup\EavSetupFactory;
+use Magento\Framework\Setup\UninstallInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+
+
+/**
+ * Uninstall
+ */
+class Uninstall implements UninstallInterface
+{
+    /**
+     * EAV setup factory
+     *
+     * @var EavSetupFactory
+     */
+    private $eavSetupFactory;
+
+    /**
+     * Customer setup factory
+     *
+     * @var CustomerSetupFactory
+     */
+    protected $customerSetupFactory;
+
+    /**
+     * Init
+     *
+     * @param EavSetupFactory $eavSetupFactory
+     * @param CustomerSetupFactory $customerSetupFactory
+     * @param ModuleDataSetupInterface $setup
+     */
+    public function __construct(
+        EavSetupFactory $eavSetupFactory,
+        CustomerSetupFactory $customerSetupFactory,
+		ModuleDataSetupInterface $setup
+    ) {
+		$this->eavSetupFactory = $eavSetupFactory;
+        $this->customerSetupFactory = $customerSetupFactory;
+		$this->setup = $setup;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function uninstall(SchemaSetupInterface $schemaSetup, ModuleContextInterface $context)
+    {
+        /** @var CustomerSetup $customerSetup */
+        $attributeCode = 'affirm_customer_mfp';
+        $customerSetup = $this->customerSetupFactory->create(['setup' => $this->setup]);
+		$customerSetup->removeAttribute(Customer::ENTITY, $attributeCode);
+
+        /** @var EavSetup $eavSetup */
+        $eavSetup = $this->eavSetupFactory->create(['setup' => $this->setup]);
+
+		if (version_compare($context->getVersion(), '0.4.2', '<')) {
+			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp');
+			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp');
+		}
+
+		if (version_compare($context->getVersion(), '0.4.3', '<')) {
+			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_type');
+			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_priority');
+			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_type');
+			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_priority');
+		}
+
+		if (version_compare($context->getVersion(), '1.0.2', '<')) {
+			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_start_date');
+			$eavSetup->removeAttribute(Product::ENTITY, 'affirm_product_mfp_end_date');
+			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_start_date');
+			$eavSetup->removeAttribute(Category::ENTITY, 'affirm_category_mfp_end_date');
+		}
+
+		if (version_compare($context->getVersion(), '1.0.3', '<')) {
+			$eavSetup->removeAttribute(
+                \Magento\Catalog\Model\Category::ENTITY,
+                'affirm_category_promo_id',
+            );
+			$eavSetup->removeAttribute(
+                \Magento\Catalog\Model\Product::ENTITY,
+                'affirm_product_promo_id',
+            );
+		}
+
+		// Drop tables
+		$schemaSetup->startSetup();
+		$this->dropTable($schemaSetup, 'astound_affirm_rule');
+		$this->dropTable($schemaSetup, 'astound_affirm_attribute');
+		$schemaSetup->endSetup();
+
+    }
+
+	 /**
+     * @param SchemaSetupInterface $schemaSetup
+     * @param string $tableName
+     */
+    private function dropTable(SchemaSetupInterface $schemaSetup, $tableName)
+    {
+        $connection = $schemaSetup->getConnection();
+        $connection->dropTable($schemaSetup->getTable($tableName));
+    }
+}


### PR DESCRIPTION
---
Uninstall Script
---

### Description
Add uninstall script to remove custom eav attributes and drop Affirm tables added by InstallSchema class. 

### How To Test
Steps to test the changes:
1. Pull this change 
2. Go to a M2 instance root with Astound_Affirm module installed
3. Run `bin/magento setup:di:compile` (to make sure changes are compiled) and run `bin/magento module:uninstall Astound_Affirm` to test the uninstall script

### Expected behavior
Once uninstall command is complete, check M2 database and `eav_attributes` table to confirm the script ran properly (`select * from eav_attribute where attribute_code like '%affirm%' LIMIT 20;`)
