### PR TITLE
optimize-contructor:

### DIFF
--- a/Block/Onepage/AffirmButton.php
+++ b/Block/Onepage/AffirmButton.php
@@ -48,7 +48,12 @@ class AffirmButton extends Template
      *
      * @var \Magento\Quote\Model\Quote
      */
-    protected $quote;
+    protected $quote = null;
+
+    /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $session;
 
     /**
      * Button template
@@ -72,8 +77,21 @@ class AffirmButton extends Template
         array $data = []
     ) {
         $this->helper = $helper;
-        $this->quote = $session->getQuote();
+        $this->session = $session;
         parent::__construct($context, $data);
+    }
+
+    /**
+     * Return current quote from checkout session.
+     * @return \Magento\Quote\Api\Data\CartInterface|\Magento\Quote\Model\Quote
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getQuote(){
+        if(null == $this->quote){
+            $this->quote = $this->session->getQuote();
+        }
+        return $this->quote;
     }
 
     /**

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -84,6 +84,11 @@ class Confirm extends Action implements CsrfAwareActionInterface
     protected $quote;
 
     /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $session;
+
+    /**
      * Inject objects to the Confirm action
      *
      * @param Context                 $context
@@ -100,10 +105,23 @@ class Confirm extends Action implements CsrfAwareActionInterface
         $this->checkout = $checkout;
         $this->checkoutSession = $checkoutSession;
         $this->quoteManagement = $quoteManager;
-        $this->quote = $checkoutSession->getQuote();
+        $this->session = $checkoutSession;
         parent::__construct($context);
     }
- 
+
+    /**
+     * Return current quote from checkout session.
+     * @return \Magento\Quote\Api\Data\CartInterface|\Magento\Quote\Model\Quote
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getQuote(){
+        if(null == $this->quote){
+            $this->quote = $this->session->getQuote();
+        }
+        return $this->quote;
+    }
+
     /**
      * @inheritDoc
      */
@@ -112,14 +130,14 @@ class Confirm extends Action implements CsrfAwareActionInterface
     ): ?InvalidRequestException {
         return null;
     }
- 
+
     /**
      * @inheritDoc
      */
     public function validateForCsrf(RequestInterface $request): ?bool
     {
         return true;
-    }      
+    }
 
     /**
      * Dispatch request
@@ -137,7 +155,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
                 $this->checkoutSession->clearHelperData();
 
                 // "last successful quote"
-                $quoteId = $this->quote->getId();
+                $quoteId = $this->getQuote()->getId();
                 $this->checkoutSession->setLastQuoteId($quoteId)->setLastSuccessQuoteId($quoteId);
 
                 // an order may be created
@@ -149,7 +167,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
                 }
                 $this->_eventManager->dispatch(
                     'affirm_place_order_success',
-                    ['order' => $order, 'quote' => $this->quote ]
+                    ['order' => $order, 'quote' => $this->getQuote() ]
                 );
                 $this->_redirect('checkout/onepage/success');
                 return;

--- a/Helper/FinancingProgram.php
+++ b/Helper/FinancingProgram.php
@@ -44,7 +44,12 @@ class FinancingProgram
      *
      * @var \Magento\Quote\Model\Quote
      */
-    protected $quote;
+    protected $quote = null;
+
+    /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $session;
 
     /**
      * Customer session
@@ -120,7 +125,7 @@ class FinancingProgram
         CategoryCollectionFactory $categoryCollectionFactory
     ) {
         $this->customerSession = $customerSession;
-        $this->quote = $session->getQuote();
+        $this->session = $session;
         $this->scopeConfig = $scopeConfig;
         $this->affirmPaymentConfig = $configAffirm;
         $this->_localeDate = $localeDate;
@@ -128,6 +133,19 @@ class FinancingProgram
         $this->categoryCollectionFactory = $categoryCollectionFactory;
 
         $this->_init();
+    }
+
+    /**
+     * Return current quote from checkout session.
+     * @return \Magento\Quote\Api\Data\CartInterface|\Magento\Quote\Model\Quote
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getQuote(){
+        if(null == $this->quote){
+            $this->quote = $this->session->getQuote();
+        }
+        return $this->quote;
     }
 
     /**
@@ -257,7 +275,7 @@ class FinancingProgram
     protected function getQuoteProductCollection()
     {
         if (null === $this->products) {
-            $visibleQuoteItems = $this->quote->getAllVisibleItems();
+            $visibleQuoteItems = $this->getQuote()->getAllVisibleItems();
             $productIds = [];
             foreach ($visibleQuoteItems as $visibleQuoteItem) {
                 $productIds[] = $visibleQuoteItem->getProductId();
@@ -496,7 +514,7 @@ class FinancingProgram
      */
     protected function getQuoteBaseGrandTotal()
     {
-        return $this->quote->getBaseGrandTotal();
+        return $this->getQuote()->getBaseGrandTotal();
     }
 
     /**

--- a/Model/GiftWrapManager.php
+++ b/Model/GiftWrapManager.php
@@ -43,7 +43,7 @@ class GiftWrapManager implements GiftWrapManagerInterface
      *
      * @var \Magento\Quote\Model\Quote
      */
-    protected $quote;
+    protected $quote = null;
 
     /**
      * Wrapping repository class
@@ -86,9 +86,21 @@ class GiftWrapManager implements GiftWrapManagerInterface
         PaymentHelper $paymentHelper
     ) {
         $this->session = $checkoutSession;
-        $this->quote = $checkoutSession->getQuote();
         $this->wrappingRepository = $objectManager->create('Magento\GiftWrapping\Api\WrappingRepositoryInterface');
         $this->imageHelper = $paymentHelper;
+    }
+
+    /**
+     * Return current quote from checkout session.
+     * @return \Magento\Quote\Api\Data\CartInterface|\Magento\Quote\Model\Quote
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getQuote(){
+        if(null == $this->quote){
+            $this->quote = $this->session->getQuote();
+        }
+        return $this->quote;
     }
 
     /**
@@ -98,7 +110,7 @@ class GiftWrapManager implements GiftWrapManagerInterface
      */
     public function getStoreId()
     {
-        return $this->quote->getStoreId();
+        return $this->getQuote()->getStoreId();
     }
 
     /**
@@ -108,14 +120,14 @@ class GiftWrapManager implements GiftWrapManagerInterface
      */
     public function getPrintedCardItem()
     {
-        $isApplicable = $this->quote->getGwAddCard();
+        $isApplicable = $this->getQuote()->getGwAddCard();
         if ($isApplicable) {
-            $printedCardPrice = $this->quote->getGwCardBasePrice();
+            $printedCardPrice = $this->getQuote()->getGwCardBasePrice();
             if ($printedCardPrice) {
                 return [
                     "display_name"   => "Printed Card",
                     "sku"            => "printed-card",
-                    "unit_price"     => Util::formatToCents($this->quote->getGwCardBasePrice()),
+                    "unit_price"     => Util::formatToCents($this->getQuote()->getGwCardBasePrice()),
                     "qty"            => 1,
                     "item_image_url" => $this->imageHelper->getPlaceholderImage(),
                     "item_url"       => $this->imageHelper->getPlaceholderImage()
@@ -131,7 +143,7 @@ class GiftWrapManager implements GiftWrapManagerInterface
      */
     public function getWrapItems()
     {
-        $wrappedIdForOrder = $this->quote->getGwId();
+        $wrappedIdForOrder = $this->getQuote()->getGwId();
         $data = [];
         if ($wrappedIdForOrder) {
             /** @var \Magento\GiftWrapping\Api\Data\WrappingInterface  $wrapItem */
@@ -177,7 +189,7 @@ class GiftWrapManager implements GiftWrapManagerInterface
      */
     protected function prepareWrapForItems($data)
     {
-        $quoteItems = $this->quote->getAllItems();
+        $quoteItems = $this->getQuote()->getAllItems();
 
         /** @var \Magento\Quote\Model\Quote\Item $item */
         foreach ($quoteItems as $item) {


### PR DESCRIPTION
- Remove $session->getQuote from constructor
- Load the quote when it is needed.

---
name: PR Template
---

### Description
- Enhancement: Remove $session->getQuote() from constructor, load the quote when it is needed. Load the quote from constructor is a bad practice, if the session hasn't loaded the quote from database, this line will load the quote from database, it increase the create object time.
- This line bypass the function loadCustomerQuote (\Magento\Checkout\Observer\LoadCustomerQuoteObserver)

### How To Reproduce
Steps to reproduce the behavior:
1. Go to 'domain.com/checkout/'
2. Login as a customer
3. Affirm constructor by passing the function loadCustomerQuote

### Expected behavior
- Affirm loads the quote after $checkoutSession->loadCustomerQuote()

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
- Improve performance and fix the issue load wrong customer quote.

### Additional information
<!--- What other information can you provide about the bug/feature? -->
