### PR TITLE
PHP 8 Support

### DIFF
--- a/Block/Promotion/AslowasAbstract.php
+++ b/Block/Promotion/AslowasAbstract.php
@@ -113,10 +113,10 @@ abstract class AslowasAbstract extends \Magento\Framework\View\Element\Template
         ConfigProvider $configProvider,
         Config $configAffirm,
         Payment $helperAffirm,
-        array $data = [],
         AsLowAs $asLowAs,
         Rule $rule,
-        CategoryCollectionFactory $categoryCollectionFactory
+        CategoryCollectionFactory $categoryCollectionFactory,
+        array $data = []
     ) {
         if (isset($data['position']) && $data['position']) {
             $this->position = $data['position'];

--- a/Block/Promotion/Banners.php
+++ b/Block/Promotion/Banners.php
@@ -122,9 +122,9 @@ class Banners extends \Magento\Framework\View\Element\Template
         Config $configAffirm,
         ConfigProvider $configProvider,
         Payment $helper,
-        array $data = [],
         Helper\FinancingProgram $fpHelper,
-        Helper\AsLowAs $alaHelper
+        Helper\AsLowAs $alaHelper,
+        array $data = []
     ) {
         $this->affirmPaymentConfig = $configAffirm;
         $this->helper = $helper;

--- a/Block/Promotion/CartPage/Aslowas.php
+++ b/Block/Promotion/CartPage/Aslowas.php
@@ -55,13 +55,13 @@ class Aslowas extends AslowasAbstract
         \Astound\Affirm\Model\Config $configAffirm,
         \Astound\Affirm\Helper\Payment $helperAffirm,
         Session $session,
-        array $data = [],
-        Helper\AsLowAs $asLowAs,
+        Helper\AsLowAs $asLowAsHelper,
         \Astound\Affirm\Helper\Rule $rule,
-        CategoryCollectionFactory $categoryCollectionFactory
+        CategoryCollectionFactory $categoryCollectionFactory,
+        array $data = []
     ) {
         $this->checkoutSession = $session;
-        parent::__construct($context, $configProvider, $configAffirm, $helperAffirm, $data, $asLowAs, $rule, $categoryCollectionFactory);
+        parent::__construct($context, $configProvider, $configAffirm, $helperAffirm, $asLowAsHelper, $rule, $categoryCollectionFactory, $data);
     }
 
     /**


### PR DESCRIPTION
---
PHP 8 Support - Move optional parameters behind required parameters
---

### Description
PHP 8 now requires optional parameters to specified after any required arguments ([source](https://www.php.net/manual/en/functions.arguments.php)): 

`Note that any optional arguments should be specified after any required arguments, otherwise they cannot be omitted from calls.`

### Expected behavior
Install or update Affirm extension with the following commands in PHP 8.1 to verify successful compilation:
```
composer require affirm/magento2
composer update
php bin/magento setup:upgrade
php bin/magento setup:di:compile
```
