### PR TITLE
Update Order Comment with Checkout Currency

### DIFF
--- a/Gateway/Request/AbstractDataBuilder.php
+++ b/Gateway/Request/AbstractDataBuilder.php
@@ -36,6 +36,7 @@ abstract class AbstractDataBuilder implements BuilderInterface
     const CHARGE_ID = 'charge_id';
     const COUNTRY_CODE = 'country_code';
     const DEFAULT_COUNTRY_CODE = 'USA';
+    const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
     /**#@-*/
 
     /**

--- a/Gateway/Request/CaptureRequest.php
+++ b/Gateway/Request/CaptureRequest.php
@@ -53,7 +53,9 @@ class CaptureRequest extends AbstractDataBuilder
             $storeId = null;
         }
         if ($this->affirmPaymentConfig->getPartialCapture($countryCode)) {
-            $_amount = $buildSubject['amount'] ? Util::formatToCents($buildSubject['amount']) : null;
+            $invoiceAmountToCapture = $payment->getAdditionalInformation(self::LAST_INVOICE_AMOUNT) ?:
+                $buildSubject['amount'];
+            $_amount = Util::formatToCents($invoiceAmountToCapture);
             $_body = [
                 'amount' => $_amount
             ];

--- a/Gateway/Request/RefundRequest.php
+++ b/Gateway/Request/RefundRequest.php
@@ -48,6 +48,7 @@ class RefundRequest extends AbstractDataBuilder
             $payment->getAdditionalInformation(self::CHARGE_ID);
         $countryCode = $payment->getAdditionalInformation(self::COUNTRY_CODE) ?: self::DEFAULT_COUNTRY_CODE;
         $creditMemoAmount = $payment->getCreditmemo()->getGrandTotal();
+        $payment->setAdditionalInformation(self::LAST_INVOICE_AMOUNT, $creditMemoAmount);
         $amountInCents = Util::formatToCents($creditMemoAmount);
         $order = $payment->getOrder();
         if($order) {

--- a/Gateway/Validator/Client/AbstractResponseValidator.php
+++ b/Gateway/Validator/Client/AbstractResponseValidator.php
@@ -32,6 +32,7 @@ abstract class AbstractResponseValidator extends AbstractValidator
     const AMOUNT = 'amount';
     const TOTAL = 'total';
     const ERROR_MESSAGE = 'message';
+    const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
     /**#@-*/
 
     /**

--- a/Plugin/SaveInvoiceAmountToCapture.php
+++ b/Plugin/SaveInvoiceAmountToCapture.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Astound\Affirm\Plugin;
+/**/
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+
+class SaveInvoiceAmountToCapture
+{
+    const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
+
+    public function beforeExecute(
+        \Magento\Sales\Model\Order\Payment\Operations\ProcessInvoiceOperation $subject,
+        OrderPaymentInterface $payment,
+        InvoiceInterface $invoice,
+        string $operationMethod
+    ) {
+        $invoiceAmountToCapture = $payment->formatAmount($invoice->getGrandTotal(), true);
+        $payment->setAdditionalInformation(self::LAST_INVOICE_AMOUNT, $invoiceAmountToCapture);
+        return null;
+    }
+}

--- a/Plugin/UpdateAuthMessage.php
+++ b/Plugin/UpdateAuthMessage.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Astound\Affirm\Plugin;
-/**/
 
 use Magento\Framework\Pricing\Helper\Data;
 use Magento\Sales\Model\Order\Payment\State\AuthorizeCommand;
@@ -10,14 +9,37 @@ use Magento\Sales\Api\Data\OrderPaymentInterface;
 
 class UpdateAuthMessage
 {
+    /**
+     * @var Data
+     */
     protected $priceHelper;
 
-    public function __construct(Data $priceHelper) {
+    /**
+     * @param Data $priceHelper
+     */
+    public function __construct(
+        Data $priceHelper
+    ) {
         $this->priceHelper = $priceHelper;
     }
 
-    public function afterExecute(AuthorizeCommand $subject, $result, OrderPaymentInterface $payment, $amount, OrderInterface $order)
-    {
+    /**
+     * Updates order comment message with current store currency amount
+     *
+     * @param AuthorizeCommand $subject
+     * @param $result
+     * @param OrderPaymentInterface $payment
+     * @param $amount
+     * @param OrderInterface $order
+     * @return \Magento\Framework\Phrase
+     */
+    public function afterExecute(
+        AuthorizeCommand $subject,
+        $result,
+        OrderPaymentInterface $payment,
+        $amount,
+        OrderInterface $order
+    ) {
         $order_currency_code = $order->getOrderCurrencyCode();
         $new_amount = $this->priceHelper->currency($amount, true, false);
         $_message = __($result->getText(), $order_currency_code . " " . $new_amount);

--- a/Plugin/UpdateAuthMessage.php
+++ b/Plugin/UpdateAuthMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Astound\Affirm\Plugin;
+/**/
+
+use Magento\Framework\Pricing\Helper\Data;
+use Magento\Sales\Model\Order\Payment\State\AuthorizeCommand;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+
+class UpdateAuthMessage
+{
+    protected $priceHelper;
+
+    public function __construct(Data $priceHelper) {
+        $this->priceHelper = $priceHelper;
+    }
+
+    public function afterExecute(AuthorizeCommand $subject, $result, OrderPaymentInterface $payment, $amount, OrderInterface $order)
+    {
+        $order_currency_code = $order->getOrderCurrencyCode();
+        $new_amount = $this->priceHelper->currency($amount, true, false);
+        $_message = __($result->getText(), $order_currency_code . " " . $new_amount);
+        return $_message;
+    }
+}

--- a/Plugin/UpdatePrependMessage.php
+++ b/Plugin/UpdatePrependMessage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Astound\Affirm\Plugin;
+
+use Magento\Framework\Pricing\Helper\Data;
+use Magento\Sales\Model\Order\Payment;
+
+class UpdatePrependMessage
+{
+    const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
+
+    protected $priceHelper;
+
+    public function __construct(Data $priceHelper) {
+        $this->priceHelper = $priceHelper;
+    }
+
+    public function beforePrependMessage(Payment $subject, $messagePrependTo)
+    {
+        $order_currency_code = $subject->getOrder()->getOrderCurrencyCode();
+        $invoice_amount = $subject->getAdditionalInformation(self::LAST_INVOICE_AMOUNT);
+        if (isset($invoice_amount)) {
+            $new_amount = $this->priceHelper->currency($invoice_amount, true, false);
+            $messagePrependTo = __($messagePrependTo->getText(), $order_currency_code . " " . $new_amount);
+            return [$messagePrependTo];
+        } else {
+            return null;
+        }
+
+    }
+}

--- a/Plugin/UpdatePrependMessage.php
+++ b/Plugin/UpdatePrependMessage.php
@@ -2,25 +2,44 @@
 
 namespace Astound\Affirm\Plugin;
 
-use Magento\Framework\Pricing\Helper\Data;
+use Magento\Sales\Model\Order\Status\History;
 use Magento\Sales\Model\Order\Payment;
+use Magento\Framework\Pricing\PriceCurrencyInterface as CurrencyInterface;
 
 class UpdatePrependMessage
 {
+    /**
+     * Constants
+     */
     const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
 
-    protected $priceHelper;
+    /**
+     * @var CurrencyInterface
+     */
+    protected $currencyInterface;
 
-    public function __construct(Data $priceHelper) {
-        $this->priceHelper = $priceHelper;
+    /**
+     * @param CurrencyInterface $currencyInterface
+     */
+    public function __construct(
+        CurrencyInterface $currencyInterface
+    ) {
+        $this->currencyInterface = $currencyInterface;
     }
 
+    /**
+     * Updates order comment message with separately stored invoice amount
+     *
+     * @param Payment $subject
+     * @param string|History $messagePrependTo
+     * @return array|void
+     */
     public function beforePrependMessage(Payment $subject, $messagePrependTo)
     {
         $order_currency_code = $subject->getOrder()->getOrderCurrencyCode();
         $invoice_amount = $subject->getAdditionalInformation(self::LAST_INVOICE_AMOUNT);
         if (isset($invoice_amount)) {
-            $new_amount = $this->priceHelper->currency($invoice_amount, true, false);
+            $new_amount = $this->currencyInterface->format($invoice_amount, false, 2);
             $messagePrependTo = __($messagePrependTo->getText(), $order_currency_code . " " . $new_amount);
             return [$messagePrependTo];
         } else {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -300,6 +300,18 @@
         <plugin name="ProductAttributes" type="Astound\Affirm\Plugin\ProductAttributes" />
     </type>
 
+    <type name="Magento\Sales\Model\Order\Payment\State\AuthorizeCommand">
+        <plugin name="UpdateAuthMessage" type="Astound\Affirm\Plugin\UpdateAuthMessage" sortOrder="1" />
+    </type>
+
+    <type name="Magento\Sales\Model\Order\Payment">
+        <plugin name="UpdatePrependMessage" type="Astound\Affirm\Plugin\UpdatePrependMessage" sortOrder="1" />
+    </type>
+
+    <type name="Magento\Sales\Model\Order\Payment\Operations\ProcessInvoiceOperation">
+        <plugin name="SaveInvoiceAmountToCapture" type="Astound\Affirm\Plugin\SaveInvoiceAmountToCapture" sortOrder="1" />
+    </type>
+
     <type name="Magento\Payment\Model\PaymentMethodList">
         <plugin name="Astound_Affirm::restrictPaymentMethods" type="\Astound\Affirm\Plugin\RestrictPaymentMethods" sortOrder="1" />
     </type>


### PR DESCRIPTION
---
Update Order Comment with Checkout Currency
---

### Description
#### Problem statement
Prior to the changes, order comments are automatically set during transaction operation by methods in classes such as `magento/module-sales/Model/Order/Payment/Operations/AuthorizeOperation`, `magento/module-sales/Model/Order/Payment/Operations/ProcessInvoiceOperation` and etc. These methods by default use base currency and not checkout currency when updating the order comments. 

#### Solution 
1. The changes introduce plugin interceptors to replace the amount values in base currency to amount values in checkout currency (`Plugin/UpdateAuthMessage.php` and `Plugin/UpdatePrependMessage.php`). 

2. To support Partial Capture, the total amount needs to be obtained from the invoice object, and from the the gateway subjects. This required the usage of another plugin (`Plugin/SaveInvoiceAmountToCapture.php`) which stores invoice total amount (which represents either the capture invoice or the refund invoice amount) in the `payment->getAdditionalInformation` attribute to be later retrieved by the plugins mentioned above. 

### Expected behavior
The changes will set the order comments in checkout currency instead of base currency. If the merchant wants to keep base currency displayed in the order comments, the following plugins can be disabled from `affirm/magento2/etc/di.xml` by adding `disabled="true"` attributes: 
- `UpdateAuthMessage`
- `UpdatePrependMessage`

### Screenshots
![Screen Shot 2022-09-08 at 1 30 59 AM](https://user-images.githubusercontent.com/9426310/189210379-d8a36ad7-4a11-48c8-8c8b-56f90dee535f.png)
