### PR TITLE
addresses syntax error

### DIFF
--- a/Model/InlineCheckout.php
+++ b/Model/InlineCheckout.php
@@ -62,7 +62,7 @@ class InlineCheckout implements InlineCheckoutInterface
         ProductMetadataInterface $productMetadata,
         Util $util,
         QuoteValidator $quoteValidator,
-        ObjectManagerInterface $objectManager,
+        ObjectManagerInterface $objectManager
     ){
         $this->session = $checkoutSession;
         $this->quote = $checkoutSession->getQuote();


### PR DESCRIPTION
---
Syntax error for PHP 7.4
---

### Description
Received below result from the code sniffer when submitting to Magento marketplace:
> 
> Errors listed below must be fixed and resubmitted to Marketplace.
> To prevent errors in the future please read our [technical standards documentation](https://github.com/magento/magento-coding-standard/wiki/Magento-Marketplace-Extensions-Verification).
> 
> File : /usr/share/eqp/PhpCodeSnifferTool/tmp/work/Model/InlineCheckout.php
> PHP syntax error: syntax error, unexpected ')', expecting variable (T_VARIABLE)
> severity : 10
> Line : 66
> Column : 1
> Source : Generic.PHP.Syntax.PHPSyntax