### PR TITLE
Use base total amounts

### DIFF
--- a/view/frontend/web/js/model/affirm.js
+++ b/view/frontend/web/js/model/affirm.js
@@ -99,9 +99,9 @@ define([
          */
         prepareTotals: function() {
             var totals = quote.getTotals()();
-            this.shippingAmount = this.convertPriceToCents(totals.shipping_amount);
-            this.total = this.convertPriceToCents(totals.grand_total);
-            this.tax_amount = this.convertPriceToCents(totals.tax_amount);
+            this.shippingAmount = this.convertPriceToCents(totals.base_shipping_amount);
+            this.total = this.convertPriceToCents(totals.base_grand_total);
+            this.tax_amount = this.convertPriceToCents(totals.base_tax_amount);
         },
 
         /**


### PR DESCRIPTION
---
Use base total amounts
---

### Description
Revert changes done in this [PR](https://github.com/Affirm/Magento2_Affirm/commit/5bcb49a75c9eaacd64e1c3021503899110289773#diff-d82ebaeb7c09d8a4b92418d5d68cd7cf936c0d0b12c20308370ccd0bf5b85612) to use base total amounts for quote attributes. This fix addresses the issue where the amount validation is failing due to the total_amount not including tax amount. 
