### PR TITLE
Fix backorder check

### DIFF
--- a/Helper/Payment.php
+++ b/Helper/Payment.php
@@ -226,13 +226,13 @@ class Payment
                 $associatedProducts = $product->getTypeInstance()->getAssociatedProducts($product);
                 foreach ($associatedProducts as $associatedProduct) {
                     $stockItem = $this->stockRegistry->getStockItem($associatedProduct->getId());
-                    if ($stockItem->getBackorders() && ($stockItem->getQty() < 1)) {
+                    if ($stockItem->getManageStock() && $stockItem->getBackorders() && ($stockItem->getQty() < 1)) {
                         $check = false;
                     }
                 }
             } else {
                 $stockItem = $this->stockRegistry->getStockItem($product->getId());
-                if ($stockItem->getBackorders() && ($stockItem->getQty() < 1)) {
+                if ($stockItem->getManageStock() && $stockItem->getBackorders() && ($stockItem->getQty() < 1)) {
                     $check = false;
                 }
             }


### PR DESCRIPTION
---
name: PR Template
---

### Description
This addresses the following edge case:
- Product has "Manage Stock" set to "No"
- Product has backorders enabled (Magento *hides* this setting when Manage Stock is off).
- Product has qty <= 0.
In this configuration, when Affirm is disabled for backordered items, the promotional message is hidden.
However, since stock management is off, the quantity of the product shouldn't matter, and the backorders setting on the product (that is hidden, with the implication of its uselessness) should also be ignored. The implication of this setting is that it's okay to order the product regardless of anything to do with stock status.

### How To Reproduce
Steps to reproduce the behavior:
1. Disable Affirm promos for backordered items.
2. Go to any product.
3. Open "Advanced inventory".
4. Set Manage stock to "Yes", then enable backorders (either of the "Allow" options).
5. Save the product.
6. Go back to it and set Manage stock to "No". Watch the backorders setting disappear (while preserving its old value in the DB).
7. Go to a PDP of the product and observe that the Affirm promo is missing.

### Expected behavior
Affirm promo shows up on PDP.

### Benefits
Users will not have to stumble through admin finding a hidden setting on the product that is *implicitly* false, even if the actual value in the database says otherwise.
