### PR TITLE
Hotfix: Fixes missing currency code error

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -755,7 +755,7 @@ class Config implements ConfigInterface
             self::CURRENCY_CODE_USD => '',
         );
 
-        if (isset($currency_code)) {
+        if (array_key_exists($currency_code, $currencyCodeToSuffix)) {
             $_suffix = $currencyCodeToSuffix[$currency_code] ?: '';
         }
         return $_suffix;


### PR DESCRIPTION
---
Hotfix: Fixes missing currency code error
---

### Description
This change fixes the following error:
```
Exception #0 (Exception): Notice: Undefined index: MXN in /var/www/html/app/code/Astound/Affirm/Model/Config.php on line 759
 
Exception #0 (Exception): Notice: Undefined index: MXN in /var/www/html/app/code/Astound/Affirm/Model/Config.php on line 759
<pre>#1 Astound\Affirm\Model\Config->getApiKeyNameByCurrency() called at [app/code/Astound/Affirm/Model/Config.php:318]
#2 Astound\Affirm\Model\Config->getPublicApiKey() called at [app/code/Astound/Affirm/Model/Config.php:696]
#3 Astound\Affirm\Model\Config->getAllAsLowAsConfig() called at [app/code/Astound/Affirm/Model/Plugin/MiniCart/AsLowAs/ConfigPlugin.php:59]
#4 Astound\Affirm\Model\Plugin\MiniCart\AsLowAs\ConfigPlugin->afterGetConfig() called at [vendor/magento/framework/Interception/Interceptor.php:146]
#5 Magento\Checkout\Block\Cart\Sidebar\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#6 Magento\Checkout\Block\Cart\Sidebar\Interceptor->___callPlugins() called at [generated/code/Magento/Checkout/Block/Cart/Sidebar/Interceptor.php:23]
```