### PR TITLE
Only Update for Affirm Payments

### DIFF
--- a/Plugin/UpdatePrependMessage.php
+++ b/Plugin/UpdatePrependMessage.php
@@ -12,6 +12,7 @@ class UpdatePrependMessage
      * Constants
      */
     const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
+    const AFFIRM_PAYMENT_TITLE = 'Affirm'
 
     /**
      * @var CurrencyInterface
@@ -36,6 +37,10 @@ class UpdatePrependMessage
      */
     public function beforePrependMessage(Payment $subject, $messagePrependTo)
     {
+        $payment_method = $subject->getMethodInstance()->getTitle();
+        if ($payment_method != AFFIRM_PAYMENT_TITLE) {
+            return null;
+        }
         $order_currency_code = $subject->getOrder()->getOrderCurrencyCode();
         $invoice_amount = $subject->getAdditionalInformation(self::LAST_INVOICE_AMOUNT);
         if (isset($invoice_amount)) {


### PR DESCRIPTION
### Description
A bug was discovered when doing partial refunds for other payment methods, in the notes section it would still show that the whole amount was refunded even though it was only partially refunded.  This was caused by a our before action.  We will now check the payment method to be affirm first before running

### How To Reproduce
Steps to reproduce the behavior:
1. Do a partial refund for a non affirm order
2. Check the notes section to see that the whole amount was refunded even though the order was only partially refunded


### Expected behavior
To show the correct refunded amount in the orders notes section

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
