### PR TITLE
Bug Fix: datepicker on promo configuration page prevents saving of configuration

### DIFF
--- a/Block/System/Config/Form/Field/Date.php
+++ b/Block/System/Config/Form/Field/Date.php
@@ -62,7 +62,7 @@ class Date extends \Magento\Config\Block\System\Config\Form\Field
             $this->_coreRegistry->registry('datepicker_loaded', 1);
         }
         $html .= '<script type="text/javascript">
-            require(["jquery"], function () {
+            require(["jquery","jquery-ui-modules/datepicker"], function (jQuery) {
                 jQuery(document).ready(function () {
                     jQuery("#' . $element->getHtmlId() . '").datepicker( { dateFormat: "mm/dd/yy" } );
                     var el = document.getElementById("' . $element->getHtmlId() . '");


### PR DESCRIPTION
---
name: Allow Affirm Promo configuration to be saved
---

### Description
Bug fix for Stores -> Configuration -> General -> Affirm Promos datepicker isn't loaded thus javascript breaks the page and prevents saving

### How To Reproduce
Steps to reproduce the behavior:
1. In the Magento 2 admin, Go to 'Stores -> Configuration -> General -> Affirm Promos'
2. Bug occurs
   - See Javascript error in the developer tools console
   - Observe the save button doesn't function
   - Observe the left hand navigation doesn't function

### Expected behavior
- Able to save configuration
- Able to use left hand navigation
- Datepicker would show for the `Start date for Financing Program value` and `End date for Financing Program value` fields

### Javascript Error thrown in Developer tools console:
```
Uncaught TypeError: jQuery(...).datepicker is not a function
```

### Benefits
Allow the configuration to be saved in the Magento admin as expected

