### PR TITLE
use laminas instead of zend

### DIFF
--- a/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
+++ b/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
@@ -139,7 +139,7 @@ class AfterShipmentSaveObserver implements ObserverInterface
                 $data = json_encode($data, JSON_UNESCAPED_SLASHES);
                 $client->setEncType('application/json');
                 $client->setRawBody($data);
-                $client->setMethod($transferObject->getMethod());
+                $client->setMethod('POST');
                 $response = $client->send();
                 $responseBody = $response->getBody();
                 $log['response'] = json_decode($responseBody, true);

--- a/Model/Plugin/Order/AddressSave/Edit.php
+++ b/Model/Plugin/Order/AddressSave/Edit.php
@@ -144,7 +144,7 @@ class Edit
                 $data = json_encode($data, JSON_UNESCAPED_SLASHES);
                 $client->setEncType('application/json');
                 $client->setRawBody($data);
-                $client->setMethod($transferObject->getMethod());
+                $client->setMethod('POST');
                 $response = $client->send();
                 $responseBody = $response->getBody();
                 $log['response'] = json_decode($responseBody, true);

--- a/Model/Plugin/Order/AddressSave/Edit.php
+++ b/Model/Plugin/Order/AddressSave/Edit.php
@@ -21,7 +21,7 @@ namespace Astound\Affirm\Model\Plugin\Order\AddressSave;
 use Magento\Sales\Controller\Adminhtml\Order\Address;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Astound\Affirm\Model\Ui\ConfigProvider;
-use Magento\Framework\HTTP\ZendClientFactory;
+use Laminas\Http\Client;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -47,7 +47,7 @@ class Edit
     /**
      * Client factory
      *
-     * @var \Magento\Framework\HTTP\ZendClientFactory
+     * @var \Laminas\Http\Client;
      */
     protected $httpClientFactory;
 
@@ -80,7 +80,7 @@ class Edit
 
     public function __construct(
         CollectionFactory $collectionFactory,
-        ZendClientFactory $httpClientFactory,
+        Client $httpClientFactory,
         ScopeConfigInterface $scopeConfig,
         StoreManagerInterface $storeManager,
         Logger $logger
@@ -138,12 +138,14 @@ class Edit
             $log['url'] = $url;
 
             try {
-                $client = $this->httpClientFactory->create();
+                $client = $this->httpClientFactory;
                 $client->setUri($url);
                 $client->setAuth($this->getPublicApiKey(), $this->getPrivateApiKey());
                 $data = json_encode($data, JSON_UNESCAPED_SLASHES);
-                $client->setRawData($data, 'application/json');
-                $response = $client->request('POST');
+                $client->setEncType('application/json');
+                $client->setRawBody($data);
+                $client->setMethod($transferObject->getMethod());
+                $response = $client->send();
                 $responseBody = $response->getBody();
                 $log['response'] = json_decode($responseBody, true);
             } catch (\Exception $e) {


### PR DESCRIPTION
---
name: Use Laminas instead of Zend for REST APIs
---

### Description
Zend Framework was deprecated but Magento was still including this package.  Starting with Magento 2.4.6 Zend is no longer an included package in Magento.  With this change we will need to use laminas to make request.


### How To Reproduce
Steps to reproduce the behavior:
1. Checkout with Affirm
2. Ensure that Auth, Capture, Refund, and Void is still working

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->
Checkout, Auth, Capture, Refund, and Void will work as normal.  Changes only affect how the request call was made

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
