### PR TITLE
Void on capture Fail

### DIFF
--- a/Gateway/Command/CaptureStrategyCommand.php
+++ b/Gateway/Command/CaptureStrategyCommand.php
@@ -25,6 +25,8 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Sales\Model\Order;
 use Astound\Affirm\Gateway\Helper\Util;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * Class CaptureStrategyCommand
@@ -44,6 +46,13 @@ class CaptureStrategyCommand implements CommandInterface
     /**#@-*/
 
     /**
+     * Payment code
+     *
+     * @var string
+     */
+    protected $methodCode = 'affirm_gateway';
+
+    /**
      * Command pool
      *
      * @var Command\CommandPoolInterface
@@ -51,14 +60,24 @@ class CaptureStrategyCommand implements CommandInterface
     private $commandPool;
 
     /**
+     * Scope configuration object
+     *
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
      * Constructor
      *
      * @param Command\CommandPoolInterface $commandPool
+     * @param ScopeConfigInterface  $scopeConfig
      */
     public function __construct(
-        Command\CommandPoolInterface $commandPool
+        Command\CommandPoolInterface $commandPool,
+        ScopeConfigInterface $scopeConfig,
     ) {
         $this->commandPool = $commandPool;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -86,16 +105,37 @@ class CaptureStrategyCommand implements CommandInterface
             }
         }
 
-        $last_invoice_amount = $paymentInfo->getAdditionalInformation(self::LAST_INVOICE_AMOUNT);
-        $amountInCents = Util::formatToCents($last_invoice_amount);
-        if ($amountInCents == 0 ) {
-            return $this->commandPool
-                ->get(self::VOID)
-                ->execute($commandSubject);    
+        if($this->getConfigData('payment_action') == 'authorize_capture'){
+            $last_invoice_amount = $paymentInfo->getAdditionalInformation(self::LAST_INVOICE_AMOUNT);
+            $amountInCents = Util::formatToCents($last_invoice_amount);
+            if ($amountInCents == 0 ) {
+                return $this->commandPool
+                    ->get(self::VOID)
+                    ->execute($commandSubject);    
+                }
         }
+
 
         return $this->commandPool
             ->get(self::ORDER_CAPTURE)
             ->execute($commandSubject);
+    }
+
+    /**
+     * Get config data
+     *
+     * @param        $field
+     * @param null   $id
+     * @param string $scope
+     * @return mixed
+     */
+    public function getConfigData($field, $id = null, $scope = ScopeInterface::SCOPE_STORE)
+    {
+        if ($this->methodCode) {
+            $path = 'payment/' . $this->methodCode . '/' . $field;
+            $res = $this->scopeConfig->getValue($path, $scope, $id);
+            return $res;
+        }
+        return false;
     }
 }

--- a/Gateway/Validator/Client/PaymentActionsValidatorCaptureFailVoid.php
+++ b/Gateway/Validator/Client/PaymentActionsValidatorCaptureFailVoid.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Astound
+ * NOTICE OF LICENSE
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to codemaster@astoundcommerce.com so we can send you a copy immediately.
+ *
+ * @category  Affirm
+ * @package   Astound_Affirm
+ * @copyright Copyright (c) 2016 Astound, Inc. (http://www.astoundcommerce.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Astound\Affirm\Gateway\Validator\Client;
+
+use Magento\Payment\Gateway\Helper\SubjectReader;
+use Astound\Affirm\Logger\Logger as affirmLogger;
+
+/**
+ * Class PaymentActionsValidatorVoid
+ */
+class PaymentActionsValidatorCaptureFailVoid extends PaymentActionsValidator
+{
+    /**
+     * Affirm logging instance
+     *
+     * @var AffirmLogger
+     */
+    protected $affirmLogger;
+
+    /**#@+
+     * Define constants
+     */
+    const RESPONSE_TYPE = 'type';
+    const RESPONSE_TYPE_VOID = 'void';
+    /**#@-*/
+
+    public function __construct(
+        AffirmLogger $affirmLogger
+    ) {
+        $this->affirmLogger = $affirmLogger;
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function validate(array $validationSubject)
+    {
+        $response = SubjectReader::readResponse($validationSubject);
+        $errorMessages = [];
+        $validationResult = $this->validateResponseCode($response)
+            && $this->validateResponseType($response);
+        
+        $this->affirmLogger->debug('Astound\Affirm\Gateway\Validator\Client\PaymentActionsValidator:validate', array('LAST_INVOICE_AMOUNT not set'));
+        
+        if (!$validationResult) {
+            $this->affirmLogger->debug('Astound\Affirm\Gateway\Validator\Client\PaymentActionsValidator:validate', array('Affirm API Failed'));
+        }
+        
+        $errorMessages = [__('Transaction has been declined, please, try again later.')];
+
+        throw new \Magento\Framework\Validator\Exception(__($errorMessages[0]));
+
+    }
+
+    /**
+     * Validate response type
+     *
+     * @param array $response
+     * @return bool
+     */
+    protected function validateResponseType(array $response)
+    {
+        return ($response[self::RESPONSE_TYPE] == self::RESPONSE_TYPE_VOID);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -91,6 +91,7 @@
                 <item name="refund" xsi:type="string">AffirmGatewayRefundCommand</item>
                 <item name="void" xsi:type="string">AffirmGatewayVoidCommand</item>
                 <item name="cancel" xsi:type="string">Astound\Affirm\Gateway\Command\CancelStrategyCommand</item>
+                <item name="caputure_fail_void" xsi:type="string">AffirmGatewayCaptureFailVoidCommand</item>
             </argument>
         </arguments>
     </virtualType>
@@ -172,6 +173,18 @@
         </arguments>
     </virtualType>
     <!-- Void command -->
+
+    <!-- Capture Fail Void command -->
+    <virtualType name="AffirmGatewayCaptureFailVoidCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AffirmGatewayVoidRequest</argument>
+            <argument name="transferFactory" xsi:type="object">AffirmClientGatewayTransferFactory</argument>
+            <argument name="client" xsi:type="object">Astound\Affirm\Gateway\Http\Client\ClientService</argument>
+            <argument name="validator" xsi:type="object">Astound\Affirm\Gateway\Validator\Client\PaymentActionsValidatorCaptureFailVoid</argument>
+            <!--<argument name="handler" xsi:type="object">Astound\Affirm\Gateway\Response\TransactionRefundHandler</argument>-->
+        </arguments>
+    </virtualType>
+    <!-- Capture Fail Void command -->
 
     <type name="Astound\Affirm\Gateway\Http\Client\ClientService">
         <arguments>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -181,7 +181,6 @@
             <argument name="transferFactory" xsi:type="object">AffirmClientGatewayTransferFactory</argument>
             <argument name="client" xsi:type="object">Astound\Affirm\Gateway\Http\Client\ClientService</argument>
             <argument name="validator" xsi:type="object">Astound\Affirm\Gateway\Validator\Client\PaymentActionsValidatorCaptureFailVoid</argument>
-            <!--<argument name="handler" xsi:type="object">Astound\Affirm\Gateway\Response\TransactionRefundHandler</argument>-->
         </arguments>
     </virtualType>
     <!-- Capture Fail Void command -->


### PR DESCRIPTION
---
name: Void order when capture fails
---

### Description
For merchants that have auth and capture enabled.  We will void the order if last invoice amount is not set when trying to capture.  This will stop active orders on Affirm when there is no order in Magento

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
