### PR TITLE
Update inline-checkout.js

### DIFF
--- a/view/frontend/web/js/action/inline-checkout.js
+++ b/view/frontend/web/js/action/inline-checkout.js
@@ -13,6 +13,13 @@ define([
     var configData = window.checkoutConfig.payment['affirm_gateway'];
     var checkoutObject
     var initAffirmInline = true
+    var options = {
+        public_api_key: window.checkoutConfig.payment['affirm_gateway'].apiKeyPublic,
+        script: window.checkoutConfig.payment['affirm_gateway'].script,
+        locale: window.checkoutConfig.payment['affirm_gateway'].locale,
+        country_code: window.checkoutConfig.payment['affirm_gateway'].countryCode,
+    };
+
     return {
         inlineCheckout: function(){
             let serviceUrl = urlBuilder.createUrl('/affirm/checkout/inline', {}), result;
@@ -20,6 +27,42 @@ define([
                 serviceUrl
             ).done(
                 function(response) {
+                    var _affirm_config = {
+                        public_api_key: options.public_api_key, /* Use the PUBLIC API KEY Affirm sent you. */
+                        script: options.script,
+                        locale: options.locale,
+                        country_code: options.country_code,
+                    };
+                    (function (m, g, n, d, a, e, h, c) {
+                        var b = m[n] || {},
+                            k = document.createElement(e),
+                            p = document.getElementsByTagName(e)[0],
+                            l = function (a, b, c) {
+                                return function () {
+                                    a[b]._.push([c, arguments]);
+                                };
+                            };
+                        b[d] = l(b, d, "set");
+                        var f = b[d];
+                        b[a] = {};
+                        b[a]._ = [];
+                        f._ = [];
+                        b._ = [];
+                        b[a][h] = l(b, a, h);
+                        b[c] = function () {
+                            b._.push([h, arguments]);
+                        };
+                        a = 0;
+                        for (c = "set add save post open empty reset on off trigger ready setProduct".split(" "); a < c.length; a++) f[c[a]] = l(b, d, c[a]);
+                        a = 0;
+                        for (c = ["get", "token", "url", "items"]; a < c.length; a++) f[c[a]] = function () {};
+                        k.async = !0;
+                        k.src = g[e];
+                        p.parentNode.insertBefore(k, p);
+                        delete g[e];
+                        f(g);
+                        m[n] = b;
+                    })(window, _affirm_config, "affirm", "checkout", "ui", "script", "ready", "jsReady");
                     if(!(checkoutObject == response)) {
                         affirm.ui.ready(function() {
                             affirm.checkout(JSON.parse(response))


### PR DESCRIPTION
---
name: Add AFJS on inline checkout
---

### Description
AFJS is no longer loading on payment selection screen.  this fix will be to load AFJS on the payment selection screen

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
