### PR TITLE
remove zend filter

### DIFF
--- a/Controller/Adminhtml/Rule/Edit.php
+++ b/Controller/Adminhtml/Rule/Edit.php
@@ -40,7 +40,7 @@ class Edit extends \Astound\Affirm\Controller\Adminhtml\Rule
         foreach ($fields as $f){
             $val = $model->getData($f);
             if (!is_array($val)){
-                $model->setData($f, explode(',', $val));
+                $model->setData($f, explode(',', $val ?? ''));
             }
         }
 

--- a/Controller/Adminhtml/Rule/Save.php
+++ b/Controller/Adminhtml/Rule/Save.php
@@ -1,5 +1,6 @@
 <?php
 namespace Astound\Affirm\Controller\Adminhtml\Rule;
+use Magento\Framework\Filter\FilterInput;
 
 class Save extends \Astound\Affirm\Controller\Adminhtml\Rule
 {
@@ -9,7 +10,7 @@ class Save extends \Astound\Affirm\Controller\Adminhtml\Rule
             try {
                 $model = $this->_objectManager->create('Astound\Affirm\Model\Rule');
                 $data = $this->getRequest()->getPostValue();
-                $inputFilter = new \Zend_Filter_Input(
+                $inputFilter = new FilterInput(
                     [],
                     [],
                     $data


### PR DESCRIPTION
---
name: Remove Zend Filter
---

### Description
Remove deprecated zend filter with new magento filger

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
