### PR TITLE
add missing var

### DIFF
--- a/Helper/FinancingProgram.php
+++ b/Helper/FinancingProgram.php
@@ -100,6 +100,13 @@ class FinancingProgram
     protected $categoryCollectionFactory;
 
     /**
+     * Config model
+     *
+     * @var \Astound\Affirm\Model\Config
+     */
+    protected $affirmPaymentConfig;
+
+    /**
      * Init
      *
      * @param Session $session

--- a/Model/Observer/IdentifyFinancingProgram.php
+++ b/Model/Observer/IdentifyFinancingProgram.php
@@ -23,11 +23,27 @@ use Magento\Framework\Event\Observer;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\RequestInterface;
 
+
 /**
  * Identify Financing Program for customer
  */
 class IdentifyFinancingProgram implements ObserverInterface
 {
+     /**
+     * Customer session
+     *
+     * @var \Magento\Customer\Model\Session
+     */
+    protected $customerSession;
+    
+    /**
+     * Request interface
+     *
+     * @var \Magento\Framework\App\RequestInterface
+     */
+    protected $request;
+    
+
     /**
      * Init
      *
@@ -36,7 +52,7 @@ class IdentifyFinancingProgram implements ObserverInterface
         Session $customerSession,
         RequestInterface $request
     ) {
-        $this->_customerSession = $customerSession;
+        $this->customerSession = $customerSession;
         $this->request = $request;
     }
 
@@ -53,7 +69,7 @@ class IdentifyFinancingProgram implements ObserverInterface
         if (empty($financingProgramValue)) {
             return;
         }
-        if ($this->_customerSession->isLoggedIn()) {
+        if ($this->customerSession->isLoggedIn()) {
             $this->_updateLoggedInCustomerMFP($financingProgramValue);
         } else {
             $this->_updateGuestCustomerMFP($financingProgramValue);
@@ -68,7 +84,7 @@ class IdentifyFinancingProgram implements ObserverInterface
      */
     protected function _updateLoggedInCustomerMFP($financingProgramValue)
     {
-        $customer = $this->_customerSession->getCustomer();
+        $customer = $this->customerSession->getCustomer();
         $customerMFPValue = $customer->getAffirmCustomerMfp();
         if (empty($customerMFPValue) || ($financingProgramValue != $customerMFPValue)) {
             $customerData = $customer->getDataModel();
@@ -87,9 +103,9 @@ class IdentifyFinancingProgram implements ObserverInterface
      */
     protected function _updateGuestCustomerMFP($financingProgramValue)
     {
-        $sessionMFPValue = $this->_customerSession->getAffirmCustomerMfp();
+        $sessionMFPValue = $this->customerSession->getAffirmCustomerMfp();
         if (empty($sessionMFPValue) || ($financingProgramValue != $sessionMFPValue)) {
-            $this->_customerSession->setAffirmCustomerMfp($financingProgramValue);
+            $this->customerSession->setAffirmCustomerMfp($financingProgramValue);
         }
     }
 }

--- a/Model/Plugin/Checkout/CustomerData/Cart.php
+++ b/Model/Plugin/Checkout/CustomerData/Cart.php
@@ -77,6 +77,13 @@ class Cart
      */
     protected $quote = null;
 
+    /**
+     * Checkout session
+     * 
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $checkoutSession = null;
+
 
     /**
      * @param \Astound\Affirm\Helper\Payment    $helperAffirm

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -70,6 +70,13 @@ class ConfigProvider implements ConfigProviderInterface
     protected $productMetadata;
 
     /**
+     * Checkout session
+     *
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $checkoutSession;
+
+    /**
      * Inject all needed object for getting data from config
      *
      * @param ConfigInterface          $config

--- a/Setup/Patch/Data/AddProductCategoryAttributes.php
+++ b/Setup/Patch/Data/AddProductCategoryAttributes.php
@@ -7,11 +7,11 @@ declare(strict_types=1);
 
 namespace Astound\Affirm\Setup\Patch\Data;
 
-use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchRevertableInterface;
-
+use Magento\Eav\Api\AttributeSetRepositoryInterface;
+use Magento\Catalog\Setup\CategorySetupFactory;
 
 /**
 * Patch is mechanism, that allows to do atomic upgrade data changes
@@ -26,14 +26,26 @@ class AddProductCategoryAttributes implements
     private $moduleDataSetup;
 
     /**
+     * @var AttributeSetRepositoryInterface $attributeSetRepositoryInterface
+     */
+    private $attributeSetRepositoryInterface;
+
+    /**
+     * @var CategorySetupFactory $categorySetupFactory
+     */
+    private $categorySetupFactory;
+
+    /**
      * @param ModuleDataSetupInterface $moduleDataSetup
      */
     public function __construct(
         ModuleDataSetupInterface $moduleDataSetup,
-        EavSetupFactory $eavSetupFactory
+        AttributeSetRepositoryInterface $attributeSetRepositoryInterface,
+        CategorySetupFactory $categorySetupFactory
     ) {
         $this->moduleDataSetup = $moduleDataSetup;
-        $this->eavSetupFactory = $eavSetupFactory;
+        $this->attributeSetRepositoryInterface = $attributeSetRepositoryInterface;
+        $this->categorySetupFactory = $categorySetupFactory;
     }
 
     /**
@@ -46,7 +58,7 @@ class AddProductCategoryAttributes implements
         $this->moduleDataSetup->getConnection()->startSetup();
 
         /** @var EavSetup $eavSetup */
-        $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
+        $eavSetup = $this->categorySetupFactory->create(['setup' => $this->moduleDataSetup]);
 
         /**
          * Add attributes to the product eav/attribute
@@ -337,7 +349,7 @@ class AddProductCategoryAttributes implements
         $this->moduleDataSetup->getConnection()->startSetup();
 
         /** @var EavSetup $eavSetup */
-        $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
+        $eavSetup = $this->categorySetupFactory->create(['setup' => $this->moduleDataSetup]);
 
         $eavSetup->removeAttribute(\Magento\Catalog\Model\Product::ENTITY, 'affirm_product_mfp');
 		$eavSetup->removeAttribute(\Magento\Catalog\Model\Category::ENTITY, 'affirm_category_mfp');


### PR DESCRIPTION
---
name: Add Missing Variables
---

### Description
PHP8.2 no long allows for creation of dynamic variables.  We now need to define these ahead of time to use

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
