### PR TITLE
Removed trailing comma to support PHP < 8

### DIFF
--- a/Gateway/Command/CaptureStrategyCommand.php
+++ b/Gateway/Command/CaptureStrategyCommand.php
@@ -74,7 +74,7 @@ class CaptureStrategyCommand implements CommandInterface
      */
     public function __construct(
         Command\CommandPoolInterface $commandPool,
-        ScopeConfigInterface $scopeConfig,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->commandPool = $commandPool;
         $this->scopeConfig = $scopeConfig;


### PR DESCRIPTION
---
name: PR Template
---

### Description
<!--- Describe the Bug/feature/enhancement you are adding in this PR. -->

### How To Reproduce
Steps to reproduce the behavior:
1. Use php 7.3 version and do composer require
2. After installing do `bin/magento setup:upgrade`
3. It should show error like below
4. Parse error: syntax error, unexpected ')', expecting variable (T_VARIABLE) in /vendor/affirm/magento2/Gateway/Command/CaptureStrategyCommand.php on line 78
PHP Parse error:  syntax error, unexpected ')', expecting variable (T_VARIABLE) in /vendor/affirm/magento2/Gateway/Command/CaptureStrategyCommand.php on line 78


5. See error

### Expected behavior
There should not be any error like that.

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
