### PR TITLE
Update afjs URL to use cdn1

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -69,7 +69,7 @@ class Config implements ConfigInterface
     const API_URL_SANDBOX = 'https://api.global-sandbox.affirm.com';
     const API_URL_PRODUCTION = 'https://api.global.affirm.com';
     const JS_URL_SANDBOX = 'https://cdn1-sandbox.affirm.com/js/v2/affirm.js';
-    const JS_URL_PRODUCTION = 'https://www.affirm.com/js/v2/affirm.js';
+    const JS_URL_PRODUCTION = 'https://cdn1.affirm.com/js/v2/affirm.js';
     const METHOD_BML = 'affirm_promo';
     const KEY_ASLOWAS = 'affirm_aslowas';
     const KEY_MFP = 'affirm_mfp';


### PR DESCRIPTION
We typically load AFJS through the `cdn1` subdomain. This change removes an extra 301 hop.