### PR TITLE
Version Bump to 3.3.1

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -69,7 +69,7 @@ class Config implements ConfigInterface
     const API_URL_SANDBOX = 'https://api.global-sandbox.affirm.com';
     const API_URL_PRODUCTION = 'https://api.global.affirm.com';
     const JS_URL_SANDBOX = 'https://cdn1-sandbox.affirm.com/js/v2/affirm.js';
-    const JS_URL_PRODUCTION = 'https://www.affirm.com/js/v2/affirm.js';
+    const JS_URL_PRODUCTION = 'https://cdn1.affirm.com/js/v2/affirm.js';
     const METHOD_BML = 'affirm_promo';
     const KEY_ASLOWAS = 'affirm_aslowas';
     const KEY_MFP = 'affirm_mfp';

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -69,7 +69,7 @@ class Config implements ConfigInterface
     const API_URL_SANDBOX = 'https://api.global-sandbox.affirm.com';
     const API_URL_PRODUCTION = 'https://api.global.affirm.com';
     const JS_URL_SANDBOX = 'https://cdn1-sandbox.affirm.com/js/v2/affirm.js';
-    const JS_URL_PRODUCTION = 'https://cdn1.affirm.com/js/v2/affirm.js';
+    const JS_URL_PRODUCTION = 'https://www.affirm.com/js/v2/affirm.js';
     const METHOD_BML = 'affirm_promo';
     const KEY_ASLOWAS = 'affirm_aslowas';
     const KEY_MFP = 'affirm_mfp';

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Astound_Affirm" setup_version="3.3.0">
+    <module name="Astound_Affirm" setup_version="3.3.1">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
---
name: Bump 3.3.1
---

### Description
Version bump uses CDN instead of www.  to decrease latency

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
