### PR TITLE
Update sandbox URL

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -66,7 +66,7 @@ class Config implements ConfigInterface
     const KEY_MINIMUM_ORDER_TOTAL = 'minimum_order_total';
     const KEY_MAXIMUM_ORDER_TOTAL = 'maximum_order_total';
     const KEY_SORT_ORDER = 'sort_order';
-    const API_URL_SANDBOX = 'https://api.global-sandbox.affirm.com';
+    const API_URL_SANDBOX = 'https://api.global.sandbox.affirm.com';
     const API_URL_PRODUCTION = 'https://api.global.affirm.com';
     const JS_URL_SANDBOX = 'https://cdn1-sandbox.affirm.com/js/v2/affirm.js';
     const JS_URL_PRODUCTION = 'https://cdn1.affirm.com/js/v2/affirm.js';


### PR DESCRIPTION
As part of the Cloudflare migration, we are updating the global sandbox URL from `api.global-sandbox.affirm.com` to `api.global.sandbox.affirm.com`. The endpoints should otherwise be identical.