### PR TITLE
French Banners

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -716,8 +716,13 @@ class Config implements ConfigInterface
     public function getAffirmAssetsUrl()
     {
         $prefix = "cdn-assets";
-        $domain = "affirm.com";
-        $assetPath = "images/banners";
+        $domain = "affirm.com";       
+        $assetPath = "images/banners/";
+
+        if ($this->getLocale() == SELF::LOCALE_FR_CA ) {
+            $assetPath = "images/banners/fr/AFFIRM-DSP-B-";
+        }
+
         return 'https://' . $prefix . '.' . $domain . '/' . $assetPath ;
     }
 

--- a/view/frontend/templates/promotion/bml.phtml
+++ b/view/frontend/templates/promotion/bml.phtml
@@ -45,7 +45,7 @@
 <?php
     echo '<div class="affirm-banner-container">
             <a class="affirm-site-modal" data-mage-init=\'{"Astound_Affirm/js/affirmWidget": '.$options.'}\'' . (!empty($mfpValue) ? 'data-promo-id="' . $mfpValue . '"' : '') . '' .(!empty($pageType) ? 'data-page-type="' . $pageType . '"' : '').'>
-                <img style="max-width:'. $width .'px; max-height:'. $height .'px; " src="' . $affirmAssetsUrl . '/' . $size .'.png">
+                <img style="max-width:'. $width .'px; max-height:'. $height .'px; " src="' . $affirmAssetsUrl . $size .'.png">
             </a>
         </div>';
 ?>


### PR DESCRIPTION
---
name: French Banners
---

### Description
When locale is fr_CA it will load french banners.  All other locales will load english banners

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
