### PR TITLE
[PSE-2398] - Log Errors to Error Tracker

### DIFF
--- a/Gateway/Http/Client/ClientService.php
+++ b/Gateway/Http/Client/ClientService.php
@@ -27,6 +27,8 @@ use Magento\Payment\Model\Method\Logger;
 use Magento\Payment\Gateway\Http\ConverterInterface;
 use Laminas\Http\Client;
 use Astound\Affirm\Logger\Logger as AffirmLogger;
+use \Magento\Framework\Module\ResourceInterface;
+use Astound\Affirm\Helper\ErrorTracker;
 
 /**
  * Class ClientService
@@ -83,12 +85,21 @@ class ClientService implements ClientInterface
     protected $util;
 
     /**
+     * Error Tracker
+     *
+     * @var ErrorTracker
+     */
+    protected $errorTracker;
+
+    /**
      * Constructor
      *
      * @param Logger $logger
      * @param ConverterInterface $converter,
      * @param Client $httpClientFactory
      * @param Action $action
+     * @param ResourceInterface $moduleResource
+     * @param ErrorTracker $error_tracker
      */
     public function __construct(
         Logger $logger,
@@ -96,7 +107,9 @@ class ClientService implements ClientInterface
         ConverterInterface $converter,
         Client $httpClientFactory,
         Action $action,
-        Util $util
+        Util $util,
+        ResourceInterface $moduleResource,
+        ErrorTracker $errorTracker
     ) {
         $this->logger = $logger;
         $this->affirmLogger = $affirmLogger;
@@ -104,6 +117,8 @@ class ClientService implements ClientInterface
         $this->httpClientFactory = $httpClientFactory;
         $this->action = $action;
         $this->util = $util;
+        $this->moduleResource = $moduleResource;
+        $this->errorTracker = $errorTracker;
     }
 
     /**
@@ -141,6 +156,21 @@ class ClientService implements ClientInterface
         } catch (\Exception $e) {
             $log['error'] = $e->getMessage();
             $this->logger->debug($log);
+
+            // Get transaction step
+            if (strpos($transferObject->getUri(), $this->action::API_CHECKOUT_PATH) !== false) {
+                $transaction_step = 'pre_auth';
+            } else {
+                $last_section = substr(strrchr($transferObject->getUri(), '/'), 1);
+                $transaction_step = $last_section ? $last_section : 'auth';
+            }
+
+            $this->errorTracker->logErrorToAffirm(
+                transaction_step: $transaction_step,
+                error_type: ErrorTracker::INTERNAL_SERVER_ERROR,
+                exception: $e
+            );
+
             throw new ClientException(__($e->getMessage()));
         } finally {
             $log['uri'] = $requestUri;

--- a/Gateway/Validator/Client/PaymentActionsValidator.php
+++ b/Gateway/Validator/Client/PaymentActionsValidator.php
@@ -94,7 +94,6 @@ class PaymentActionsValidator extends AbstractResponseValidator
         $validationResult = $this->validateResponseCode($response)
             && $this->validateTotalAmount($response, $amountInCents);
 
-        $validationResult = false;
         if (!$validationResult) {
             $errorMessages = (isset($response[self::ERROR_MESSAGE])) ?
                 [__($response[self::ERROR_MESSAGE]) . __(' Affirm status code: ') . $response[self::RESPONSE_CODE]]:

--- a/Gateway/Validator/Client/PaymentActionsValidatorCaptureFailVoid.php
+++ b/Gateway/Validator/Client/PaymentActionsValidatorCaptureFailVoid.php
@@ -64,6 +64,12 @@ class PaymentActionsValidatorCaptureFailVoid extends PaymentActionsValidator
         
         $errorMessages = [__('Transaction has been declined, please, try again later.')];
 
+        $this->errorTracker(
+            transaction_step: self::RESPONSE_TYPE_VOID,
+            error_type: ErrorTracker::TRANSACTION_DECLINED,
+            error_message: $errorMessages[0]->render()
+        );
+
         throw new \Magento\Framework\Validator\Exception(__($errorMessages[0]));
 
     }

--- a/Gateway/Validator/Client/PaymentActionsValidatorVoid.php
+++ b/Gateway/Validator/Client/PaymentActionsValidatorVoid.php
@@ -45,6 +45,11 @@ class PaymentActionsValidatorVoid extends PaymentActionsValidator
 
         if (!$validationResult) {
             $errorMessages = [__('Transaction has been declined, please, try again later.')];
+            $this->errorTracker(
+                transaction_step: self::RESPONSE_TYPE_VOID,
+                error_type: ErrorTracker::TRANSACTION_DECLINED,
+                error_message: $errorMessages[0]->render()
+            );
         }
 
         return $this->createResult($validationResult, $errorMessages);

--- a/Helper/ErrorTracker.php
+++ b/Helper/ErrorTracker.php
@@ -21,8 +21,8 @@ namespace Astound\Affirm\Helper;
 use \Magento\Framework\Module\ResourceInterface;
 use Magento\Framework\HTTP\AsyncClientInterface;
 use Magento\Framework\HTTP\AsyncClient\Request;
-use Magento\Payment\Model\Method\Logger;
 use Astound\Affirm\Model\Config as ConfigAffirm;
+use Magento\Framework\App\ProductMetadataInterface;
 
 /**
  * Error tracker helper - sends error back to Affirm for monitoring
@@ -59,19 +59,29 @@ class ErrorTracker
     private $httpClient;
 
     /**
+     * Product metadata
+     *
+     * @var \Magento\Framework\App\ProductMetadataInterface
+     */
+    protected $productMetadata;
+
+    /**
      * Constructor
      * @param ResourceInterface $moduleResource
      * @param AsyncClientInterface $httpClient
      * @param ConfigAffirm $configAffirm
+     * @param ProductMetadataInterface $productMetadata
      */
     public function __construct(
         ResourceInterface $moduleResource,
         AsyncClientInterface $httpClient,
-        ConfigAffirm $configAffirm
+        ConfigAffirm $configAffirm,
+        ProductMetadataInterface $productMetadata
     ) {
         $this->moduleResource = $moduleResource;
         $this->httpClient = \Magento\Framework\App\ObjectManager::getInstance()->get(AsyncClientInterface::class);
         $this->affirmConfig = $configAffirm;
+        $this->productMetadata = $productMetadata;
     }
 
     /**
@@ -97,7 +107,8 @@ class ErrorTracker
             'environment'=>$this->affirmConfig->getMode() == 'sandbox' ? 'sandbox' : 'live',
             'language'=>'php',
             'code_version'=>phpversion(),
-            'extension_version'=>$this->moduleResource->getDbVersion('Astound_Affirm')
+            'extension_version'=>$this->moduleResource->getDbVersion('Astound_Affirm'),
+            'platform_version' => $this->productMetadata->getVersion() . ' ' . $this->productMetadata->getEdition()
         ];
         if ($exception) {
             $error_data = (object)[

--- a/Helper/ErrorTracker.php
+++ b/Helper/ErrorTracker.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Astound
+ * NOTICE OF LICENSE
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to codemaster@astoundcommerce.com so we can send you a copy immediately.
+ *
+ * @category  Affirm
+ * @package   Astound_Affirm
+ * @copyright Copyright (c) 2016 Astound, Inc. (http://www.astoundcommerce.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Astound\Affirm\Helper;
+
+use \Magento\Framework\Module\ResourceInterface;
+use Magento\Framework\HTTP\AsyncClientInterface;
+use Magento\Framework\HTTP\AsyncClient\Request;
+use Magento\Payment\Model\Method\Logger;
+use Astound\Affirm\Model\Config as ConfigAffirm;
+
+/**
+ * Error tracker helper - sends error back to Affirm for monitoring
+ *
+ * @package Astound\Affirm\Helper
+ */
+class ErrorTracker
+{
+
+    /**#@+
+     * Define constants
+     */
+    const POST = 'POST';
+    const MAX_TRACE_FRAMES = 10;
+
+    // The error_types accepted at the Affirm endpoint
+    const INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR';
+    const INVALID_AMOUNT = 'INVALID_AMOUNT';
+    const TRANSACTION_DECLINED = 'TRANSACTION_DECLINED';
+    /**#@-*/
+
+    /**
+     * Affirm config model
+     *
+     * @var \Astound\Affirm\Model\Config
+     */
+    protected $affirmConfig;
+
+    /**
+     * @var AsyncClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * Constructor
+     * @param ResourceInterface $moduleResource
+     * @param AsyncClientInterface $httpClient
+     * @param ConfigAffirm $configAffirm
+     */
+    public function __construct(
+        ResourceInterface $moduleResource,
+        AsyncClientInterface $httpClient,
+        ConfigAffirm $configAffirm
+    ) {
+        $this->moduleResource = $moduleResource;
+        $this->httpClient = \Magento\Framework\App\ObjectManager::getInstance()->get(AsyncClientInterface::class);
+        $this->affirmConfig = $configAffirm;
+    }
+
+    /**
+     * Sends error information back to Affirm to be logged and monitored
+     * If the exception is given, we will also send back information about the exception like the stack trace.
+     * If the error message is not given, we default to the error type or (if given) the exception message.
+     *
+     * @param string $transaction_step
+     * @param string $error_message
+     * @param string $error_type
+     * @param \Exception $exception
+     */
+    public function logErrorToAffirm(
+        string $transaction_step,
+        string $error_type,
+        string $error_message=null,
+        \Exception $exception=null
+    )
+    {
+        // Form the object
+        $extension_data = (object)[
+            'platform'=>'magento',
+            'environment'=>$this->affirmConfig->getMode() == 'sandbox' ? 'sandbox' : 'live',
+            'language'=>'php',
+            'code_version'=>phpversion(),
+            'extension_version'=>$this->moduleResource->getDbVersion('Astound_Affirm')
+        ];
+        if (!is_null($exception)) {
+            $error_data = (object)[
+                'error_type'=>$error_type,
+                'error_message'=>$error_message ? $error_message : $exception->getMessage(),
+                'error_class'=>get_class($exception),
+                'trace'=>$this->formatStackTraces($exception)
+            ];
+        } else {
+            $error_data = (object)[
+                'error_type'=>$error_type,
+                'error_message'=>$error_message ? $error_message : $error_type
+            ];
+        }
+
+        $error_tracker_obj = (object)[
+            "extension_data"=>$extension_data,
+            "transaction_step"=>$transaction_step,
+            "error_data"=>$error_data
+        ];
+
+        $tracker_endpoint = 'https://jojotle-thor-kite.affirm-thor.com/api/v1/partnersolutions/platform/tracker';
+        $headers = [
+            'Content-Type'=>'application/json',
+            // TODO: Fix for prod
+            // 'Authorization'=>'Basic ' . base64_encode($this->affirmConfig->getPublicApiKey() . ':' . $this->affirmConfig->getPrivateApiKey())
+            'Authorization'=>'Basic ' . base64_encode('PreSeededApiKeyDirect' . ':' . 'PreSeededSecretKeyDirect')
+        ];
+
+        // Send it and forget about it
+        $response = $this->httpClient->request(
+            new Request(
+                $tracker_endpoint,
+                self::POST,
+                $headers,
+                json_encode($error_tracker_obj)
+            )
+        );
+
+        // TODO: Remove - only here for debugging purposes
+        \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Psr\Log\LoggerInterface::class)->debug("AAA: " . $response->get()->getBody());
+    }
+
+    /**
+     * Format the stack traces for the custom endpoint
+     * @param \Exception $exception
+     * @return array
+     */
+    private function formatStackTraces(\Exception $exception)
+    {
+        $frames = array_slice($exception->getTrace(), 0, self::MAX_TRACE_FRAMES);
+
+        $trace = [];
+        foreach ($frames as $frame) {
+            array_push($trace, (object)[
+                "filename"=>$frame['file'],
+                "lineno"=>$frame['line'],
+                "method"=>$frame['function']
+            ]);
+        }
+
+        return $trace;
+    }
+}


### PR DESCRIPTION
---
[[PSE-2398](https://jira.team.affirm.com/browse/PSE-2398)] -  Log Errors to Error Tracker
---

### Description
Errors that fail locally are hard to track and monitor since they are not sent back to Affirm. By sending a request containing error information back to our Affirm endpoint, we will be able to observe errors through Chronosphere, Kibana, and Rollbar to help alert us of any issues that arise.

### How To Reproduce
We don't expect to encounter exceptions in our flow so to reproduce this behavior, we have to intentionally throw one. I've been editing the code to throw an exception.

Steps to reproduce the behavior:
1. Throw an exception/create a false validation result in ClientService or the PaymentActionValidator, respectively
2. Check Chronosphere, Kibana, and Rollbar for error
    - On Kibana, check for evid: ".log_error_tracker_to_kibana"
    - On Chronosphere, check for counter: "platform_error_tracker_total"
    - On Rollbar, check under project affirm-magento-2 (to be renamed)

Note: Only Rollbar will have the stack trace if one is provided. 

### Expected behavior
- The error sent to https://affirm.com/api/v1/partnersolutions/platform/tracker (in corresponding Affirm environment)
- The error is logged to Chronosphere, Kibana, and Rollbar at the endpoint. (Note that because of enabled sampling on prod, only 10% of errors sent to the error tracker endpoint are logged)

### Benefits
By reporting errors back to Affirm and logging them to our various monitoring platforms, we will be able to increase availability by decreasing the time it takes to identify and address errors.
