### PR TITLE
Update affirmWidget.js

### DIFF
--- a/view/frontend/web/js/affirmWidget.js
+++ b/view/frontend/web/js/affirmWidget.js
@@ -6,7 +6,8 @@
 /*jshint jquery:true*/
 define([
     "jquery",
-    "Astound_Affirm/js/model/aslowas"
+    "Astound_Affirm/js/model/aslowas",
+    "jquery-ui-modules/widget"
 ], function ($, aslowas) {
 
     "use strict"


### PR DESCRIPTION
As it has been reported already on the issue #53, the removal of the "jquery-ui-modules/widget" RequireJS dependency through the commit 0acaadd is causing "Uncaught TypeError: $.widget is not a function" errors, when the jquery-ui-modules/widget dependency is not already loaded. Due to the fact that the jquery-ui-modules/widget dependency may be loaded by other scripts, this error may not be easily reproducible, depending on the order in which the JavaScript files have been loaded.

This is causing JavaScript errors on product pages, which in our case was preventing the "ADD TO WISH LIST" button from working.

Similarly to others, we had to develop a custom patch to address this issue.

Please revert these changes as soon as possible.