### PR TITLE
Fixed Astound\Affirm\Gateway\Validator\Client\PaymentActionsValidatorVoid class

### DIFF
--- a/Gateway/Validator/Client/PaymentActionsValidatorVoid.php
+++ b/Gateway/Validator/Client/PaymentActionsValidatorVoid.php
@@ -20,7 +20,9 @@ namespace Astound\Affirm\Gateway\Validator\Client;
 
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Astound\Affirm\Helper\ErrorTracker;
-
+use Astound\Affirm\Gateway\Helper\Util;
+use Magento\Payment\Gateway\Validator\ResultInterface;
+use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
 /**
  * Class PaymentActionsValidatorVoid
  */
@@ -42,10 +44,12 @@ class PaymentActionsValidatorVoid extends PaymentActionsValidator
     public $errorTracker;
 
     public function __construct(
-        \Astound\Affirm\Helper\ErrorTracker $errorTracker
+        ResultInterfaceFactory $resultFactory,
+        ErrorTracker $errorTracker,
+        Util $util
     )
     {
-        $this->errorTracker = $errorTracker;
+        parent::__construct($resultFactory, $errorTracker, $util);
     }
     
     /**


### PR DESCRIPTION
Problem of class was simple:
constructor, used there never called parent's constructor, so Depenedcy Injections of parent constructor was ingored. This lead to `$this->createResult(...` at 71 line, causing error, because it calls parent's `createResult` from `Magento\Payment\Gateway\Validator\AbstractValidator`, and it uses `$this->resultInterfaceFactory`, which is unexpeted null, because parent constuctor never set up this value, because of parent::__construc() was never called, and DI's values wass never passed there.

---
name: Fix PaymentActionsValidatorVoid class
---

### Description
Fixed constructor, that was cause error: 

[2024-05-08T07:54:28.859710+00:00] main.CRITICAL: Error: Call to a member function create() on null in .../vendor/magento/module-payment/Gateway/Validator/AbstractValidator.php:43
Stack trace:
#0 .../vendor/affirm/magento2/Gateway/Validator/Client/PaymentActionsValidatorVoid.php(71): Magento\Payment\Gateway\Validator\AbstractValidator->createResult()
#1 .../vendor/magento/module-payment/Gateway/Command/GatewayCommand.php(109): Astound\Affirm\Gateway\Validator\Client\PaymentActionsValidatorVoid->validate()
#2 .../vendor/affirm/magento2/Gateway/Command/CancelStrategyCommand.php(74): Magento\Payment\Gateway\Command\GatewayCommand->execute()
#3 .../vendor/magento/module-payment/Model/Method/Adapter.php(549): Astound\Affirm\Gateway\Command\CancelStrategyCommand->execute()
#4 .../vendor/magento/module-payment/Model/Method/Adapter.php(488): Magento\Payment\Model\Method\Adapter->executeCommand()
#5 .../generated/code/Magento/Payment/Model/Method/Adapter/Interceptor.php(275): Magento\Payment\Model\Method\Adapter->cancel()
#6 .../vendor/magento/module-sales/Model/Order/Payment.php(1165): Magento\Payment\Model\Method\Adapter\Interceptor->cancel()
#7 .../vendor/magento/module-sales/Model/Order/Payment.php(895): Magento\Sales\Model\Order\Payment->_void()
#8 .../vendor/magento/module-sales/Model/Order.php(1278): Magento\Sales\Model\Order\Payment->cancel()
#9 .../vendor/magento/module-sales/Model/Service/OrderService.php(107): Magento\Sales\Model\Order->cancel()
#10 .../vendor/magento/framework/Interception/Interceptor.php(58): Magento\Sales\Model\Service\OrderService->cancel()
#11 .../vendor/magento/framework/Interception/Interceptor.php(138): Magento\Sales\Model\Service\OrderService\Interceptor->___callParent()
#12 .../vendor/magento/framework/Interception/Interceptor.php(153): Magento\Sales\Model\Service\OrderService\Interceptor->Magento\Framework\Interception\{closure}()
#13 .../generated/code/Magento/Sales/Model/Service/OrderService/Interceptor.php(23): Magento\Sales\Model\Service\OrderService\Interceptor->___callPlugins()
#14 .../vendor/magento/module-sales/Controller/Adminhtml/Order/Cancel.php(35): Magento\Sales\Model\Service\OrderService\Interceptor->cancel()
#15 .../vendor/magento/framework/Interception/Interceptor.php(58): Magento\Sales\Controller\Adminhtml\Order\Cancel->execute()
#16 .../vendor/magento/framework/Interception/Interceptor.php(138): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->___callParent()
#17 .../vendor/magento/framework/Interception/Interceptor.php(153): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->Magento\Framework\Interception\{closure}()
#18 .../generated/code/Magento/Sales/Controller/Adminhtml/Order/Cancel/Interceptor.php(23): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->___callPlugins()
#19 .../vendor/magento/framework/App/Action/Action.php(111): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->execute()
#20 .../vendor/magento/module-backend/App/AbstractAction.php(151): Magento\Framework\App\Action\Action->dispatch()
#21 .../vendor/magento/framework/Interception/Interceptor.php(58): Magento\Backend\App\AbstractAction->dispatch()
#22 .../vendor/magento/framework/Interception/Interceptor.php(138): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->___callParent()
#23 .../vendor/magento/module-backend/App/Action/Plugin/Authentication.php(145): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->Magento\Framework\Interception\{closure}()
#24 .../vendor/magento/framework/Interception/Interceptor.php(135): Magento\Backend\App\Action\Plugin\Authentication->aroundDispatch()
#25 .../vendor/magento/framework/Interception/Interceptor.php(153): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->Magento\Framework\Interception\{closure}()
#26 .../generated/code/Magento/Sales/Controller/Adminhtml/Order/Cancel/Interceptor.php(32): Magento\Sales\Controller\Adminhtml\Order\Cancel\Interceptor->___callPlugins()

### How To Reproduce
Steps to reproduce the behavior:
1. Create any Affirm order
2. Try to cancel it via admin panel
3. See error 

### Expected behavior
<!--- Order must be canceled in magento and voided in affirm -->

### Screenshots
![image](https://github.com/Affirm/Magento2_Affirm/assets/41078064/c96ef326-13aa-4c23-94a0-9e662263fa9c)

