### PR TITLE
Admin Support canada order dashboard URL

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -20,6 +20,8 @@ namespace Astound\Affirm\Block;
 
 use Magento\Framework\Phrase;
 use Magento\Payment\Block\ConfigurableInfo;
+use Magento\Sales\Model\Order;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Payment Block Info class
@@ -97,8 +99,28 @@ class Info extends ConfigurableInfo
      */
     public function getAdminAffirmUrl()
     {
+        /** @var Order $order */
+        $order = $this->getInfo()->getOrder();
+        $mode = $this->_scopeConfig->getValue(
+            'payment/affirm_gateway/mode',
+            ScopeInterface::SCOPE_STORE,
+            $order->getStoreId()
+        );
+
+        $isSandbox = $mode === 'sandbox';
+        $country = $this->getInfo()->getOrder()->getPayment()->getAdditionalInformation('country_code') ?? 'USA';
+        $isCanada = $country === 'CAN';
+
+        $domain = $isCanada ? 'www.affirm.ca' : 'www.affirm.com';
+        if ($isSandbox) {
+            $domain = $isCanada ? 'sandbox.affirm.ca' : 'sandbox.affirm.com';
+        }
+
         $loanId = $this->getLoanId();
-        return sprintf('https://%s/dashboard/#/details/%s?trk=%s', $this->getDomainUrl(), $loanId,
+        return sprintf(
+            'https://%s/dashboard/#/details/%s?trk=%s',
+            $domain,
+            $loanId,
             $this->getPublicApiKey()
         );
     }

--- a/view/adminhtml/templates/payment/info/edit.phtml
+++ b/view/adminhtml/templates/payment/info/edit.phtml
@@ -2,8 +2,7 @@
 // @codingStandardsIgnoreFile
 
 /**
- * @var \Magento\Payment\Block\Info $block
- * @see \Magento\Payment\Block\Info
+ * @var \Astound\Affirm\Block\Info $block
  */
 $specificInfo = $block->getSpecificInformation();
 $title = $block->escapeHtml($block->getMethod()->getTitle());


### PR DESCRIPTION
Today, if a customer places an order on the `CA` environment, the link to the `US` domain is used, which causes a 404 error.

The objective of this MR is to correct this bug by using the correct domain according to the country, as well as:

**Production :**

- For `CA`:  https://www.affirm.ca/dashboard/#/details/XXX
- For `US`: https://www.affirm.com/dashboard/#/details/XXX

**Sandbox :**

- For `CA`:  https://www.sandbox.affirm.ca/dashboard/#/details/XXX
- For `US`: https://www.sandbox.affirm.com/dashboard/#/details/XXX

