### PR TITLE
Fix : Load Region Model Correctly

### DIFF
--- a/Model/Observer/AddressFormat.php
+++ b/Model/Observer/AddressFormat.php
@@ -38,17 +38,17 @@ class AddressFormat implements ObserverInterface
      */
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
-
+        /** @var $address \Magento\Sales\Model\Order\Address */
         $address = $observer->getEvent()->getAddress();
         if($address->getAddressType()) {
-            if ($address->getRegion() == null) {
-                $regionId = $address->getRegionId();
+            if ($address->getRegionId() !== null && $address->getRegion() === null) {
                 /** @var \Magento\Directory\Model\Region $region */
-                $region = $this->regionFactory->create();
-                $region->loadByCode($region, $regionId);
-                $address->setRegion($region->getName());
-                $address->setRegionCode($region->getCode());
-                $address->save();
+                $region = $this->regionFactory->create()->load($address->getRegionId());
+                if($region->getId()) {
+                    $address->setRegion($region->getName());
+                    $address->setRegionCode($region->getCode());
+                    $address->save();   
+                }
             }
         }
 


### PR DESCRIPTION
If region Id exist the model should be loaded by ->load() method instead of loadByCode().

---
name: Load Region Model Correctly
---

### Description
Load Region Model Correctly

### How To Reproduce
Steps to reproduce the behavior:
I discovered this issue after installing this module. After this module installed new order mails are could not been sent.
And got this exception log
`[2024-08-29T12:14:58.711410+00:00] .CRITICAL: Error: Object of class Magento\Directory\Model\Region could not be converted to string in /home/magento/vendor/magento/module-directory/Model/ResourceModel/Region.php:143
Stack trace:
#0 /home/magento/vendor/magento/module-directory/Model/Region.php(59): Magento\Directory\Model\ResourceModel\Region->loadByCode()
#1 /home/magento/vendor/affirm/magento2/Model/Observer/AddressFormat.php(48): Magento\Directory\Model\Region->loadByCode()`

Then I discovered this bug in code.

### Expected behavior
If the region name was missing should be filled correctly via this observer

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
Fixes the issue

### Additional information
<!--- What other information can you provide about the bug/feature? -->
