### PR TITLE
Fix beforeExecute EditOrder

### DIFF
--- a/Model/Plugin/Order/EditOrder.php
+++ b/Model/Plugin/Order/EditOrder.php
@@ -49,10 +49,9 @@ class EditOrder
      * Plugin for save order after edit
      *
      * @param SaveAction $controller
-     * @param callable   $method
      * @return \Magento\Framework\Controller\Result\Redirect
      */
-    public function beforeExecute(SaveAction $controller, \Closure $method)
+    public function beforeExecute(SaveAction $controller)
     {
         $data = $controller->getRequest()->getParam('payment');
         if (isset($data['method']) && $data['method'] == \Astound\Affirm\Model\Ui\ConfigProvider::CODE) {
@@ -60,6 +59,6 @@ class EditOrder
             $resultRedirect->setPath('affirm/affirm/error');
             return $resultRedirect;
         }
-        return $method();
+        return $controller;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "affirm/magento2",
     "description": "Affirm's extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "require": {
         "php": "~7.4.0||~8.1.0||~8.2.0||~8.3.0"
     },


### PR DESCRIPTION
---
name: Fix beforeExecute EditOrder
---

### Description
Fixing beforeExecute for EditOrder.

Function now returns controller back to original function

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
