### PR TITLE
Fix Region code String instead of passing object

### DIFF
--- a/Model/Observer/AddressFormat.php
+++ b/Model/Observer/AddressFormat.php
@@ -45,7 +45,7 @@ class AddressFormat implements ObserverInterface
                 $regionId = $address->getRegionId();
                 /** @var \Magento\Directory\Model\Region $region */
                 $region = $this->regionFactory->create();
-                $region->loadByCode($region, $regionId);
+                $region->loadByCode($address->getRegion(), $regionId);
                 $address->setRegion($region->getName());
                 $address->setRegionCode($region->getCode());
                 $address->save();


### PR DESCRIPTION
[2024-12-06T15:40:02.775548+00:00] main.CRITICAL: Error: Object of class Magento\Directory\Model\Region could not be converted to string in /home/u15e64ec4506f3/public_html/vendor/magento/module-directory/Model/ResourceModel/Region.php:143 Stack trace:
#0 ./vendor/magento/module-directory/Model/Region.php(59): Magento\Directory\Model\ResourceModel\Region->loadByCode() #1 ./vendor/affirm/magento2/Model/Observer/AddressFormat.php(48): Magento\Directory\Model\Region->loadByCode() ...

---
name: PR Template
---

### Description
<!--- Describe the Bug/feature/enhancement you are adding in this PR. -->

### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
