### PR TITLE
Fix : Define _affirm_config as global variable

### DIFF
--- a/view/frontend/web/js/model/aslowas.js
+++ b/view/frontend/web/js/model/aslowas.js
@@ -168,6 +168,7 @@ define([
              * Load affirm script
              *
              * @private
+             * @see https://docs.affirm.com/payments/docs/afjs-reference#including-and-initializing-affirmjs
              */
             loadScript: function(options) {
                 var pubKey = options.public_api_key,
@@ -175,12 +176,13 @@ define([
                     locale = options.locale,
                     countryCode = options.country_code
 
-                _affirm_config = {
+                window._affirm_config = {
                     public_api_key: pubKey, /* Use the PUBLIC API KEY Affirm sent you. */
                     script: script,
                     locale: locale,
                     country_code: countryCode,
                 };
+
                 (function (m, g, n, d, a, e, h, c) {
                     var b = m[n] || {},
                         k = document.createElement(e),
@@ -210,7 +212,7 @@ define([
                     delete g[e];
                     f(g);
                     m[n] = b;
-                })(window, _affirm_config, "affirm", "checkout", "ui", "script", "ready", "jsReady");
+                })(window, window._affirm_config, "affirm", "checkout", "ui", "script", "ready", "jsReady");
             },
 
             /**


### PR DESCRIPTION
## Description (*)

I tried to configure the Affirm widget to use the local `fr_CA` but it does not work, the message is still displayed in English :(

In the code everything is good:

```html
<div data-mage-init='{"Astound_Affirm/js/aslowasPDP": {"logo":"black","script":"https:\/\/cdn1.affirm.ca\/js\/v2\/affirm.js","public_api_key":"XXX","min_order_total":"30","max_order_total":"30000","selector":".product-info-main","currency_rate":"1.000000000000","backorders_options":[],"element_id":"als_pdp","country_code":"CAN","locale":"fr_CA"}}'>
        <p id="als_pdp" data-amount="0" class="affirm-as-low-as" data-page-type="product"  data-affirm-color="black" data-learnmore-show="true"></p>        <span class="__affirm-logo __affirm-logo-black __ligature__affirm_full_logo__" aria-hidden="true" style="opacity: 0;position: absolute">Affirm</span>
    </div>
```

![Capture d’écran du 2025-01-31 12-20-58](https://github.com/user-attachments/assets/2a752b2d-456d-4181-847c-212313c2cadf)

In the [following documentation](https://docs.affirm.com/payments/docs/integrate-promotional-messaging#example), the `_affirm_config` variable is defined globally - therefore available in the `window` variable. However, in the Magento module this variable is not defined in window but only locally ...

![Capture d’écran du 2025-01-31 12-22-31](https://github.com/user-attachments/assets/07d1d023-f8db-479f-81d5-5a4baeadfa4a)

In the [js/v2/affirm.js](https://cdn1.affirm.ca/js/v2/affirm.js
) locale is loaded from `window._affirm_config`.

## How To Reproduce

- In Magento BO, config affirm with fr_CA locale
- Go to product page
- The Affirm widget is displayed in English :boom: 

## Expected behavior

If widget Affirm is config with fr_CA locale, the widget must be displayed in French ! 


