### PR TITLE
Fix : Return to cart if token not provider in /confirm page

### DIFF
--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -187,5 +187,7 @@ class Confirm implements CsrfAwareActionInterface
                 return $resultRedirect->setPath('checkout/cart');
             }
         }
+
+        return $resultRedirect->setPath('checkout/cart');
     }
 }


### PR DESCRIPTION
### Description

If user go to `/affirm/payment/confirm` 

- **development mode** : the following error is displayed `Invalid return type` 
- **production mode** : blank page is displayed


### How To Reproduce
Steps to reproduce the behavior:

1. Go to `/affirm/payment/confirm` without token
2. 💥 Critical error is displayed because the controller return void

### Expected behavior

If not token provider (for different reason), the customer must be redirect to `/cart`
