### PR TITLE
Update PaymentActionsValidator.php

### DIFF
--- a/Gateway/Validator/Client/PaymentActionsValidator.php
+++ b/Gateway/Validator/Client/PaymentActionsValidator.php
@@ -112,7 +112,7 @@ class PaymentActionsValidator extends AbstractResponseValidator
             $this->errorTracker->logErrorToAffirm(
                 transaction_step: $transaction_step,
                 error_type: ErrorTracker::TRANSACTION_DECLINED,
-                error_message: $errorMessages[0]->render()
+                error_message: $errorMessages[0]
             );
             
             throw new \Magento\Framework\Validator\Exception(__($errorMessages[0]));


### PR DESCRIPTION
An error was encountered when attempting to invoice an order paid through Affirm. The error was encountered when attempting to log the error message, specifically when the $validationResult variable was set to false, indicating that the response could not be validated. Since the translation has already been rendered, the $errorMessages[0] variable is of type string and the \Magento\Framework\Phrase::render() function cannot be used.