### PR TITLE
Bump to version 4.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "affirm/magento2",
     "description": "Affirm's extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "4.0.6",
+    "version": "4.0.7",
     "require": {
         "php": "~7.4.0||~8.1.0||~8.2.0||~8.3.0"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Astound_Affirm" setup_version="4.0.6">
+    <module name="Astound_Affirm" setup_version="4.0.7">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
---
name: Bump to version 4.0.7
---

### Description
We need to do a new release for Magento to update our listing so that it works for magento version 2.4.8.  Magento does not allow us to update our listing to show that is works 2.4.8 without doing a version bump


### How To Reproduce
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->

### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->

### Additional information
<!--- What other information can you provide about the bug/feature? -->
