### PR TITLE
[Bugfix] - Double Calling Collect Totals Breaks MariaDB 11.8 on Magento 2.4.8-p5

### DIFF
--- a/Model/AffirmCheckoutManager.php
+++ b/Model/AffirmCheckoutManager.php
@@ -168,7 +168,9 @@ class AffirmCheckoutManager implements AffirmCheckoutManagerInterface
     public function initCheckout()
     {
         // collection totals before submit
-        $this->quote->collectTotals();
+        if (!$this->quote->getTotalsCollectedFlag()) {
+            $this->quote->collectTotals();
+        }
         $this->quote->reserveOrderId();
         $orderIncrementId = $this->quote->getReservedOrderId();
         $discountAmount = $this->quote->getBaseSubtotal() - $this->quote->getBaseSubtotalWithDiscount();


### PR DESCRIPTION


---
name: [Bugfix] - Double Calling Collect Totals Breaks MariaDB 11.8 on Magento 2.4.8-p5
---

### Description
<!--- Describe the Bug/feature/enhancement you are adding in this PR. -->
After upgrading to Magento 2.4.8-p5 and MariaDB 11.8.6 there is a new MariaDB feature `innodb_snapshot_isolation`. This now throws an error on trying to run database queries on entries that no longer exist. After placing a successful test order with Affirm 4.0.9 - Any subsequent orders fail with error:
```
SQLSTATE[HY000]: General error: 1020 Record has changed since last read in table 'quote_shipping_rate', query was: DELETE FROM `quote_shipping_rate` WHERE (rate_id IN ('106'))
```
This is referencing a shipping rate that has been previously deleted. Older versions of Mariadb silently fail, and handle this gracefully.

This comes from `AffirmCheckoutManager::initCheckout()` calling collectTotals.
CollectTotals triggers `$shippingAddress->collectShippingRates()` which calls the delete.

### How To Reproduce
Steps to reproduce the behavior:
1. MariaDB 11.8.6
2. Affirm 4.0.9
3. Magento 2.4.8-p5
4. Place an order locally
5. Attempt to place a second order locally
6. Checkout throws an error as above.

### Expected behavior
<!--- What is the expected behavior? How is it going to work? What is it going to fix? -->
Checkout should popup affirm modal and allow second order to be placed.

### Screenshots
<!--- If applicable, add screenshots to help explain your bug or feature. -->
Error:
Red blocks to block out PII.
<img width="860" height="857" alt="Screenshot 2026-05-19 at 15 53 30" src="https://github.com/user-attachments/assets/50b87a93-a614-47cd-bfa1-79553634b116" />


### Benefits
<!--- How do you think this feature or enhamcement would improve Affirm and Magento experience? -->
It would allow a customer to place multiple orders in succession.

### Additional information
<!--- What other information can you provide about the bug/feature? -->
This MR wraps collect totals in an if to check if it needs to call collect totals first. This is due to mariadb 11.8.x now having innodb snapshot on, which breaks checkout on double calling collect totals. The error comes from collectTotals triggering $shippingAddress->collectShippingRates() which has already been called. This didnt used to be a problem, and was gracefully handled, but new MariaDB versions now throw an error.
