### PR TITLE
Fix inline checkout burning an order increment ID on every call

### DIFF
--- a/Model/InlineCheckout.php
+++ b/Model/InlineCheckout.php
@@ -10,6 +10,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Quote\Model\QuoteValidator;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
 
 /**
  * Class InlineCheckout
@@ -57,6 +58,11 @@ class InlineCheckout implements InlineCheckoutInterface
     public $objectManager;
 
     /**
+     * @var CartRepositoryInterface
+     */
+    private $quoteRepository;
+
+    /**
      * Gift card id cart key
      *
      * @var string
@@ -78,7 +84,8 @@ class InlineCheckout implements InlineCheckoutInterface
         ProductMetadataInterface $productMetadata,
         Util $util,
         QuoteValidator $quoteValidator,
-        ObjectManagerInterface $objectManager
+        ObjectManagerInterface $objectManager,
+        CartRepositoryInterface $quoteRepository
     ){
         $this->session = $checkoutSession;
         $this->quote = $checkoutSession->getQuote();
@@ -88,14 +95,32 @@ class InlineCheckout implements InlineCheckoutInterface
         $this->util = $util;
         $this->quoteValidator = $quoteValidator;
         $this->objectManager = $objectManager;
+        $this->quoteRepository = $quoteRepository;
     }
 
     public function initInline(){
         $quote = $this->quote;
+
+        // The inline endpoint fires on every checkout form.change() and is exposed anonymously at
+        // GET /V1/affirm/checkout/inline. A quote that can never become an order (no quote row,
+        // empty cart) must not reserve - reserveOrderId() draws and permanently burns a sequence
+        // value on every call, advancing order numbers far faster than actual sales.
+        if (!$quote->getId() || (int)$quote->getItemsCount() === 0) {
+            return json_encode(array());
+        }
+
         $quote->collectTotals();
 
         if(!$quote->getReservedOrderId()) {
             $quote->reserveOrderId();
+            // Persist so the next request loads a quote that already carries a reserved_order_id and
+            // the guard above stops re-drawing. Best-effort: a failed save just means the next call
+            // redraws (prior behavior), so it never errors this high-frequency endpoint.
+            try {
+                $this->quoteRepository->save($quote);
+            } catch (\Exception $e) {
+                // ignore - fall back to prior behavior (next call redraws)
+            }
         }
 
         try{


### PR DESCRIPTION
### Description

`Astound\Affirm\Model\InlineCheckout::initInline()` reserves an order increment ID via `Quote::reserveOrderId()` but never persists the quote. `reserveOrderId()` draws a value from the store's `sequence_order_*` table — an `INSERT` that is never rolled back — and is guarded only by the **in-memory** `if (!$quote->getReservedOrderId())`. Because the quote is never saved, every fresh request reloads a quote with no reserved id and draws again, permanently burning a sequence value (a gap in order numbers).

The endpoint is called far more than once per checkout: `affirm_gateway.js` binds `inlineCheckout()` to `$('form').change()`, so a shopper tabbing through checkout fields burns an id per change. It is also exposed anonymously at `GET /V1/affirm/checkout/inline`, so a session-less/bot request burns one too.

This PR:
- **Skips reservation for quotes that can never become an order** (no quote row / empty cart) — closing the anonymous-request burn vector and avoiding junk quote rows.
- **Persists the quote when a reservation is made** (via an injected `CartRepositoryInterface`), so the next request loads a quote that already carries `reserved_order_id` and the existing in-memory guard becomes effective across requests — one id per quote instead of one per request. The save is best-effort, so it can never error this high-frequency endpoint.

### How To Reproduce

Steps to reproduce the behavior:
1. Enable Affirm inline checkout and go to checkout with a cart.
2. Note the current max of the store's `sequence_order_<store_id>` table.
3. Tab through / change several checkout form fields (each `form.change()` calls the inline endpoint), or request `GET /V1/affirm/checkout/inline` several times directly.
4. See that `sequence_order_<store_id>` has advanced by one per call while no order was placed — order numbers advance far faster than actual sales.

### Expected behavior

The inline endpoint reserves at most **one** order id per quote (persisted so subsequent calls reuse it) and does not reserve at all for empty or session-less quotes. The reserved id stays unique and is still re-validated at order placement. Order-number gaps caused by repeated inline calls no longer occur.

### Screenshots

N/A — backend/data behavior.

### Benefits

Merchants stop seeing order numbers advance far faster than real sales, which otherwise reads as "failed/lost orders" and complicates reconciliation. It also removes needless growth of the `sequence_order_*` tables and aligns Affirm with core payment methods (e.g. `Magento\Paypal\Model\Express\Checkout`) that already reserve-and-persist during checkout.

### Additional information

Increment-id integrity is preserved: draws stay unique (`Sequence::getNextValue()` is `INSERT` + `lastInsertId`), order placement re-validates any pre-existing reserved id via `Magento\Sales\Model\OrderIncrementIdChecker` and redraws if it was consumed, and the DB unique index `(increment_id, store_id)` is a hard backstop. The same reserve-and-persist pattern already ships in core PayPal Express, ParadoxLabs Auth.net, and Amazon Pay.
