### PR TITLE
Fix 404 on shipment tracking update to Affirm (json_encode on transaction ID)

### DIFF
--- a/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
+++ b/Model/Adminhtml/Observer/AfterShipmentSaveObserver.php
@@ -125,7 +125,7 @@ class AfterShipmentSaveObserver implements ObserverInterface
             $orderAdditionalInfo = $order->getPayment()->getAdditionalInformation();
             $transactionId = $orderAdditionalInfo[self::TRANSACTION_ID] ?:
                 $orderAdditionalInfo[self::CHARGE_ID];
-            $url = $this->getApiUrl(json_encode($transactionId));
+            $url = $this->getApiUrl($transactionId);
             $data = [
                 'order_id' => $orderIncrementId,
                 'shipping_carrier' => $shippingCarrier,


### PR DESCRIPTION
## Summary
- `AfterShipmentSaveObserver::execute` ran the Affirm transaction ID through `json_encode()` before concatenating it into the API URL, producing a malformed path like `/api/v1/transactions/"ID"` instead of `/api/v1/transactions/ID`.
- Affirm's API returned `404 not_found` on every call as a result, so shipping carrier/tracking info was never delivered to Affirm for any order on affected merchants.
- Confirmed via merchant debug log: every `AfterShipmentSaveObserver::execute` entry logged a 404, immediately following a successful `.../capture` call using the *same*, unquoted transaction ID.
- `Gateway/Request/CaptureRequest.php` pulls the transaction ID from the identical source (`transaction_id` / `charge_id` payment additional info) and passes it through unmodified into its URL builder — which is why captures always succeeded while this observer's tracking update always failed.

## Fix
Drop the `json_encode()` call so the transaction ID is passed to `getApiUrl()` as a plain string, matching how every other call site in the codebase builds this URL.

## Test plan
- [ ] Create a shipment on an Affirm-paid order and confirm the debug log shows a successful (non-404) response from `AfterShipmentSaveObserver::execute`
- [ ] Verify shipping carrier/tracking number appear on the transaction in Affirm's merchant dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)