### PR TITLE
Include merchant public_api_key in inline checkout payload

### DIFF
--- a/Model/InlineCheckout.php
+++ b/Model/InlineCheckout.php
@@ -10,6 +10,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Quote\Model\QuoteValidator;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
+use Astound\Affirm\Model\Config as ConfigAffirm;
 
 /**
  * Class InlineCheckout
@@ -50,6 +51,11 @@ class InlineCheckout implements InlineCheckoutInterface
     private $quoteValidator;
 
     /**
+     * @var \Astound\Affirm\Model\Config
+     */
+    private $affirmConfig;
+
+    /**
      * Object manager
      *
      * @var \Magento\Framework\ObjectManagerInterface
@@ -78,7 +84,8 @@ class InlineCheckout implements InlineCheckoutInterface
         ProductMetadataInterface $productMetadata,
         Util $util,
         QuoteValidator $quoteValidator,
-        ObjectManagerInterface $objectManager
+        ObjectManagerInterface $objectManager,
+        ConfigAffirm $affirmConfig
     ){
         $this->session = $checkoutSession;
         $this->quote = $checkoutSession->getQuote();
@@ -88,11 +95,13 @@ class InlineCheckout implements InlineCheckoutInterface
         $this->util = $util;
         $this->quoteValidator = $quoteValidator;
         $this->objectManager = $objectManager;
+        $this->affirmConfig = $affirmConfig;
     }
 
     public function initInline(){
         $quote = $this->quote;
         $quote->collectTotals();
+        $publicApiKey = $this->affirmConfig->getPublicApiKey();
 
         if(!$quote->getReservedOrderId()) {
             $quote->reserveOrderId();
@@ -108,6 +117,7 @@ class InlineCheckout implements InlineCheckoutInterface
                     'user_cancel_url'              => $this->urlBuilder
                         ->getUrl('affirm/payment/cancel', ['_secure' => true]),
                     'user_confirmation_url_action' => 'POST',
+                    'public_api_key'                => $publicApiKey,
                 ),
                 'order_id' => $quote->getReservedOrderId(),
                 'total'    => $this->util->formatToCents($quote->getGrandTotal())
@@ -124,6 +134,7 @@ class InlineCheckout implements InlineCheckoutInterface
                 'user_cancel_url'              => $this->urlBuilder
                     ->getUrl('affirm/payment/cancel', ['_secure' => true]),
                 'user_confirmation_url_action' => 'POST',
+                'public_api_key'                => $publicApiKey,
             ),
             'order_id' => $quote->getReservedOrderId(),
             'shipping_amount' => $this->util->formatToCents($quote->getShippingAddress()->getShippingAmount()),

--- a/view/frontend/web/js/action/inline-checkout.js
+++ b/view/frontend/web/js/action/inline-checkout.js
@@ -40,14 +40,78 @@ define([
 ], function ($,storage, urlBuilder) {
     'use strict';
     var configData = window.checkoutConfig.payment['affirm_gateway'];
-    var checkoutObject
-    var initAffirmInline = true
     var options = {
         public_api_key: window.checkoutConfig.payment['affirm_gateway'].apiKeyPublic,
         script: window.checkoutConfig.payment['affirm_gateway'].script,
         locale: window.checkoutConfig.payment['affirm_gateway'].locale,
         country_code: window.checkoutConfig.payment['affirm_gateway'].countryCode,
     };
+
+    /**
+     * The real Affirm SDK and its own bootstrap stub both live at window.affirm, so
+     * existence alone can't tell them apart. The stub's method list never includes
+     * "inline", so a real .checkout.inline function is what marks the SDK as loaded.
+     */
+    function isAffirmSdkReady() {
+        return !!(window.affirm && window.affirm.checkout && typeof window.affirm.checkout.inline === 'function');
+    }
+
+    /**
+     * Affirm's standard async-loader snippet. Only runs when the SDK isn't already
+     * loaded - running it again after a successful load would overwrite the real
+     * affirm.checkout with a fresh stub (which has no .inline method) and re-insert
+     * another <script src="affirm.js"> into the page.
+     */
+    function loadAffirmSdk(affirmConfig) {
+        if (isAffirmSdkReady()) {
+            return;
+        }
+        (function (m, g, n, d, a, e, h, c) {
+            var b = m[n] || {},
+                k = document.createElement(e),
+                p = document.getElementsByTagName(e)[0],
+                l = function (a, b, c) {
+                    return function () {
+                        a[b]._.push([c, arguments]);
+                    };
+                };
+            b[d] = l(b, d, "set");
+            var f = b[d];
+            b[a] = {};
+            b[a]._ = [];
+            f._ = [];
+            b._ = [];
+            b[a][h] = l(b, a, h);
+            b[c] = function () {
+                b._.push([h, arguments]);
+            };
+            a = 0;
+            for (c = "set add save post open empty reset on off trigger ready setProduct".split(" "); a < c.length; a++) f[c[a]] = l(b, d, c[a]);
+            a = 0;
+            for (c = ["get", "token", "url", "items"]; a < c.length; a++) f[c[a]] = function () {};
+            k.async = !0;
+            k.src = g[e];
+            p.parentNode.insertBefore(k, p);
+            delete g[e];
+            f(g);
+            m[n] = b;
+        })(window, affirmConfig, "affirm", "checkout", "ui", "script", "ready", "jsReady");
+    }
+
+    /**
+     * Applies the latest checkout data and (re)renders the inline widget, deferred
+     * until the real SDK has replaced the bootstrap stub.
+     */
+    function renderInlineCheckout(response) {
+        affirm.ui.ready(function() {
+            affirm.checkout(JSON.parse(response))
+            affirm.checkout.inline({
+                merchant: {
+                    inline_container: "affirm-inline-checkout"
+                },
+            });
+        })
+    }
 
     return {
         inlineCheckout: function(){
@@ -62,53 +126,8 @@ define([
                         locale: options.locale,
                         country_code: options.country_code,
                     };
-                    (function (m, g, n, d, a, e, h, c) {
-                        var b = m[n] || {},
-                            k = document.createElement(e),
-                            p = document.getElementsByTagName(e)[0],
-                            l = function (a, b, c) {
-                                return function () {
-                                    a[b]._.push([c, arguments]);
-                                };
-                            };
-                        b[d] = l(b, d, "set");
-                        var f = b[d];
-                        b[a] = {};
-                        b[a]._ = [];
-                        f._ = [];
-                        b._ = [];
-                        b[a][h] = l(b, a, h);
-                        b[c] = function () {
-                            b._.push([h, arguments]);
-                        };
-                        a = 0;
-                        for (c = "set add save post open empty reset on off trigger ready setProduct".split(" "); a < c.length; a++) f[c[a]] = l(b, d, c[a]);
-                        a = 0;
-                        for (c = ["get", "token", "url", "items"]; a < c.length; a++) f[c[a]] = function () {};
-                        k.async = !0;
-                        k.src = g[e];
-                        p.parentNode.insertBefore(k, p);
-                        delete g[e];
-                        f(g);
-                        m[n] = b;
-                    })(window, _affirm_config, "affirm", "checkout", "ui", "script", "ready", "jsReady");
-                    if(!(checkoutObject == response)) {
-                        affirm.ui.ready(function() {
-                            affirm.checkout(JSON.parse(response))
-                            affirm.checkout.inline({
-                                merchant: {
-                                    inline_container: "affirm-inline-checkout"
-                                },
-                            });
-                        })
-                        initAffirmInline = false
-                    } else {
-                        affirm.checkout.inline({
-                            container: "affirm-inline-checkout",
-                            data: JSON.parse(response),
-                        });
-                    }
-                    checkoutObject = response
+                    loadAffirmSdk(_affirm_config);
+                    renderInlineCheckout(response);
                 }
             ).fail(
                 function (response) {
@@ -118,28 +137,19 @@ define([
         },
 
         updateInlineCheckout : function(){
-            var _self = this;
             let serviceUrl = urlBuilder.createUrl('/affirm/checkout/inline', {}), result;
             storage.get(
                 serviceUrl
             ).done(
                 function(response) {
-                    setTimeout(function(){
-                        $('.action-apply').click(function(){
-                            _self.updateInlineCheckout()
-                        })
-                        $('.action-cancel').click(function(){
-                            _self.updateInlineCheckout()
-                        })
-                        $('.action-update').click(function(){
-                            _self.updateInlineCheckout()
-                        })
-                    },
-                    3000);
-                    affirm.checkout.inline({
-                        container: "affirm-inline-checkout",
-                        data: JSON.parse(response),
-                    });
+                    var _affirm_config = {
+                        public_api_key: options.public_api_key,
+                        script: options.script,
+                        locale: options.locale,
+                        country_code: options.country_code,
+                    };
+                    loadAffirmSdk(_affirm_config);
+                    renderInlineCheckout(response);
                 }
             ).fail(
                 function (response) {

--- a/view/frontend/web/js/view/payment/method-renderer/affirm_gateway.js
+++ b/view/frontend/web/js/view/payment/method-renderer/affirm_gateway.js
@@ -105,18 +105,25 @@ define(
             getEduHTML: function() {
                 if (window.checkoutConfig.payment['affirm_gateway'].edu) {
                     let timestamp = 1
-                    $('form').change(function(e){
+                    // Namespaced + off-before-on so re-invoking getEduHTML() never stacks
+                    // duplicate handlers (each duplicate would re-trigger the same coupon
+                    // action / form-change call on every subsequent event).
+                    $('form').off('change.affirmInline').on('change.affirmInline', function(e){
                         if (timestamp == 1 || e.timeStamp > timestamp+500) {
                             timestamp = e.timeStamp
                             inlineCheckout.inlineCheckout()
                         }
                     })
 
-                    $('.action-apply').click(function(){
+                    $('.action-apply').off('click.affirmInline').on('click.affirmInline', function(){
                         inlineCheckout.updateInlineCheckout()
                     })
 
-                    $('.action-cancel').click(function(){
+                    $('.action-cancel').off('click.affirmInline').on('click.affirmInline', function(){
+                        inlineCheckout.updateInlineCheckout()
+                    })
+
+                    $('.action-update').off('click.affirmInline').on('click.affirmInline', function(){
                         inlineCheckout.updateInlineCheckout()
                     })
 


### PR DESCRIPTION
## Summary
- `InlineCheckout::initInline()`'s `merchant` object never included `public_api_key`, so the Affirm-hosted iframe URL built from this payload for the inline checkout widget ends up with an empty `merchant_public_key` param while every other param (amount, device_id, frameId, origin) is populated correctly. Confirmed live that `window.checkoutConfig.payment['affirm_gateway'].apiKeyPublic` carries the correct key throughout — this endpoint's response was the one place in the chain structurally missing it. Fixed by injecting the existing `Astound\Affirm\Model\Config` service (same DI pattern already used in `Model/Ui/ConfigProvider.php`) and adding `public_api_key` to both `merchant` array branches in `initInline()`.
- `inline-checkout.js`'s `inlineCheckout()` ran Affirm's full async-loader snippet on every throttled (~500ms) form-change event and every coupon action, not just once. That loader unconditionally rebuilds `window.affirm.checkout` as a fresh stub even when the real SDK was already loaded — and the stub never has an `.inline` method — so any subsequent `affirm.checkout.inline()` call can throw `Uncaught TypeError: affirm.checkout.inline is not a function`. Two call sites also invoked `.inline()` without waiting on `affirm.ui.ready()` at all. Fixed by extracting the loader into `loadAffirmSdk()`, guarded to skip entirely once a real `.checkout.inline` function (not just a truthy `window.affirm`) is present, and routing every render through one `ui.ready()`-wrapped helper.
- `updateInlineCheckout()` re-bound `.action-apply`/`.action-cancel`/`.action-update` click handlers via `.click()` inside its own AJAX success callback on every call, stacking duplicate handlers with each coupon action. Removed that rebinding; moved the binding to `affirm_gateway.js`'s `getEduHTML()` using namespaced `off()`/`on()` so it's idempotent regardless of how often `getEduHTML()` itself re-runs.

## Note on #155
This touches the same method (`InlineCheckout::initInline()`) as #155 (order-increment-ID burn fix), so there's a merge-conflict risk between the two. Also a sequencing note: #155 makes the `/affirm/checkout/inline` response stable across repeated calls for an unchanged cart, which will make the previously-rare "unchanged response" code path in `inlineCheckout()` far more common — this PR is what makes that path safe (ui.ready-wrapped), so this should land no later than #155.

## Test plan
- [ ] Load the inline checkout widget and confirm the resulting `https://www.affirm.com/products/inline_checkout?...` request has a non-empty `merchant_public_key`
- [ ] DevTools Network: filter `affirm.js`, confirm it loads once — not once per form-change event
- [ ] Edit address/shipping fields repeatedly; confirm no `affirm.checkout.inline is not a function` error in console
- [ ] Apply/cancel a coupon multiple times; confirm one `/affirm/checkout/inline` request per action (not accumulating duplicate handlers) and the widget re-renders with updated totals
- [ ] Requires `bin/magento setup:static-content:deploy -f` + cache flush on the test instance before these JS changes take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)