### PR TITLE
Fix: capture validator falsely declines successful captures when no amount was sent

### DIFF
--- a/Gateway/Request/AbstractDataBuilder.php
+++ b/Gateway/Request/AbstractDataBuilder.php
@@ -37,6 +37,7 @@ abstract class AbstractDataBuilder implements BuilderInterface
     const COUNTRY_CODE = 'country_code';
     const DEFAULT_COUNTRY_CODE = 'USA';
     const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
+    const CAPTURE_AMOUNT_SPECIFIED = 'capture_amount_specified';
     /**#@-*/
 
     /**

--- a/Gateway/Request/CaptureRequest.php
+++ b/Gateway/Request/CaptureRequest.php
@@ -63,6 +63,11 @@ class CaptureRequest extends AbstractDataBuilder
         } else {
             $_body = [];
         }
+        // Record whether we actually told Affirm what to capture. When partial_capture is off,
+        // the body above is empty and Affirm captures the full remaining authorized balance
+        // server-side — Magento's invoice grand-total has no guaranteed relationship to that
+        // value, so PaymentActionsValidator shouldn't compare against it.
+        $payment->setAdditionalInformation(self::CAPTURE_AMOUNT_SPECIFIED, !empty($_body));
         return [
             'path' => "{$transactionId}/capture",
             'storeId' => $storeId,

--- a/Gateway/Validator/Client/AbstractResponseValidator.php
+++ b/Gateway/Validator/Client/AbstractResponseValidator.php
@@ -33,6 +33,7 @@ abstract class AbstractResponseValidator extends AbstractValidator
     const TOTAL = 'total';
     const ERROR_MESSAGE = 'message';
     const LAST_INVOICE_AMOUNT = 'last_invoice_amount';
+    const CAPTURE_AMOUNT_SPECIFIED = 'capture_amount_specified';
     /**#@-*/
 
     /**

--- a/Gateway/Validator/Client/PaymentActionsValidator.php
+++ b/Gateway/Validator/Client/PaymentActionsValidator.php
@@ -100,9 +100,17 @@ class PaymentActionsValidator extends AbstractResponseValidator
 
         $amountInCents = $this->util->formatToCents($amount);
 
+        // Capture is the one step where Magento may not have told Affirm an amount at all
+        // (partial_capture disabled -> Affirm captures the full remaining authorized balance
+        // server-side). The invoice grand-total has no guaranteed relationship to that
+        // server-computed value, so only enforce the amount match when we actually specified
+        // one. Authorize/pre-auth/refund always send an explicit amount, so they're unaffected.
+        $shouldValidateAmount = $transaction_step !== 'capture'
+            || $_payment->getAdditionalInformation(self::CAPTURE_AMOUNT_SPECIFIED);
+
         $errorMessages = [];
         $validationResult = $this->validateResponseCode($response)
-            && $this->validateTotalAmount($response, $amountInCents);
+            && (!$shouldValidateAmount || $this->validateTotalAmount($response, $amountInCents));
 
         if (!$validationResult) {
             $errorMessages = (isset($response[self::ERROR_MESSAGE])) ?

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "affirm/magento2",
     "description": "Affirm's extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "4.0.9",
+    "version": "4.0.10",
     "require": {
         "php": "~8.1.0||~8.2.0||~8.3.0||~8.4"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Astound_Affirm" setup_version="4.0.9">
+    <module name="Astound_Affirm" setup_version="4.0.10">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
### Description
`PaymentActionsValidator::validate()` is shared across authorize, capture, and refund. For capture, when `partial_capture` isn't enabled for the merchant's country, `CaptureRequest::build()` sends an **empty** request body — no amount specified, meaning "capture the full remaining authorized balance." The response then gets compared against Magento's locally-computed invoice grand-total, which has no guaranteed relationship to that server-computed value (tax/shipping recalculation, rounding, partial invoicing).

When they diverge, the comparison fails and `validate()` throws inside Magento's order-placement transaction — even though the capture genuinely succeeded. The order rolls back, but the customer has already been charged, with nothing linking the charge to an order.

### Fix
- `CaptureRequest::build()` now records whether an amount was actually specified in the capture request.
- `PaymentActionsValidator::validate()` only enforces the amount check for the capture step when that flag is set; otherwise it trusts the response code alone.
- Authorize, pre-auth, and refund are untouched — they always send an explicit amount, so the comparison stays valid there.

### Testing
No unit test harness exists in this repo for the `Gateway/Validator`/`Gateway/Request` classes. Verified against a local Magento 2.4.8 sandbox configured with `payment_action=authorize_capture` and `partial_capture` off (the conditions that trigger this bug):

| Case | Before | After |
| --- | --- | --- |
| Capture, amount mismatch, no amount specified | Throws | Passes |
| Capture, amount mismatch, amount specified | Throws | Throws (unchanged) |
| Capture, amount matches | Passes | Passes |
| Authorize, amount mismatch | Throws | Throws (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
